### PR TITLE
fix: remove redundant `@Waitable`  from callback_group_id

### DIFF
--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -43,11 +43,7 @@ std::string create_callback_group_id(
     ss << "Timer(" << period << ")@";
   };
 
-  auto waitable_func = [&ss](const rclcpp::Waitable::SharedPtr &waitable) {
-    (void)waitable;
-    ss << "Waitable"
-       << "@";
-  };
+  auto waitable_func = [](auto &&) {};
 
   group->collect_all_ptrs(sub_func, service_func, client_func, timer_func,
                           waitable_func);


### PR DESCRIPTION
## Description

This removes the redundant `@Waitable`  from callback_group_id preserving backward compatibility.

## Related links

## How was this PR tested?

### prerun

The redundant `@Waitable`s are not outputed.

```
callback_groups:
  - id: /sample_node@Subscription(/parameter_events)@Service(/sample_node/get_parameters)@Service(/sample_node/get_parameter_types)@Service(/sample_node/set_parameters)@Service(/sample_node/set_parameters_atomically)@Service(/sample_node/describe_parameters)@Service(/sample_node/list_parameters)
    affinity: ~
    policy: SCHED_OTHER
    priority: 0

  - id: /sample_node@Subscription(/topic_in)
    affinity: ~
    policy: SCHED_OTHER
    priority: 0
```

### run

Even if the old-version config is specified, the thread configurator works correctly.

```
$ ros2 run cie_thread_configurator thread_configurator_node --config-file template_old.yaml 
callback_groups:
  - id: /sample_node@Subscription(/parameter_events)@Service(/sample_node/get_parameters)@Service(/sample_node/get_parameter_types)@Service(/sample_node/set_parameters)@Service(/sample_node/set_parameters_atomically)@Service(/sample_node/describe_parameters)@Service(/sample_node/list_parameters)@Waitable@Waitable@Waitable@Waitable
    affinity: ~
    policy: SCHED_OTHER
    priority: 0
  - id: /sample_node@Subscription(/topic_in)@Waitable
    affinity: ~
    policy: SCHED_OTHER
    priority: 0
  - id: /sample_node@Timer(1333000000)
    affinity: ~
    policy: SCHED_OTHER
    priority: 0
  - id: /sample_node@Timer(3000000000)
    affinity: ~
    policy: SCHED_OTHER
    priority: 0
[INFO] [1761249572.556376986] [thread_configurator_node]: Received CallbackGroupInfo: tid=2553028 | /sample_node@Subscription(/parameter_events)@Service(/sample_node/get_parameters)@Service(/sample_node/get_parameter_types)@Service(/sample_node/set_parameters)@Service(/sample_node/set_parameters_atomically)@Service(/sample_node/describe_parameters)@Service(/sample_node/list_parameters)
[INFO] [1761249572.556554787] [thread_configurator_node]: Received CallbackGroupInfo: tid=2553030 | /sample_node@Timer(1333000000)
[INFO] [1761249572.556586398] [thread_configurator_node]: Received CallbackGroupInfo: tid=2553031 | /sample_node@Subscription(/topic_in)
[INFO] [1761249572.556606673] [thread_configurator_node]: Received CallbackGroupInfo: tid=2553029 | /sample_node@Timer(3000000000)
```

## Notes for reviewers
