### PR TITLE
fix: probability of use-after-free

### DIFF
--- a/callback_isolated_executor/src/callback_isolated_executor.cpp
+++ b/callback_isolated_executor/src/callback_isolated_executor.cpp
@@ -62,7 +62,7 @@ void CallbackIsolatedExecutor::spin() {
     auto callback_group_id =
         cie_thread_configurator::create_callback_group_id(group, node);
 
-    threads.emplace_back([executor, &callback_group_id, &client_publisher,
+    threads.emplace_back([executor, callback_group_id, &client_publisher,
                           &client_publisher_mutex]() {
       auto tid = static_cast<pid_t>(syscall(SYS_gettid));
 


### PR DESCRIPTION
## Description

Fixed a use-after-free bug in `CallbackIsolatedExecutor::spin()` where `callback_group_id` was being captured by reference in a lambda that outlives its scope.

The previous implementation may lead to following garbled text:

```
[cie_listener-1] callback_group_id: Ω�M��A9Urde@Subscription(/ros_other_topic)
[cie_listener-1] callback_group_id: Ω�M��A9Urde@Subscription(/ros_other_topic)
```

## Related links

## How was this PR tested?

## Notes for reviewers
