### PR TITLE
fix: dirty

### DIFF
--- a/callback_isolated_executor/src/component_container_callback_isolated.cpp
+++ b/callback_isolated_executor/src/component_container_callback_isolated.cpp
@@ -145,7 +145,7 @@ void ComponentManagerCallbackIsolated::add_node_to_executor(uint64_t node_id) {
           {
             std::lock_guard<std::mutex> lock(this->client_publisher_mutex_);
             cie_thread_configurator::publish_callback_group_info(
-              this->client_publisher_, tid, group_id);
+                this->client_publisher_, tid, group_id);
           }
 
           executor_wrapper.thread_initialized = true;


### PR DESCRIPTION
## Description

This solves https://github.com/tier4/callback_isolated_executor/issues/18.

## Related links

close: https://github.com/tier4/callback_isolated_executor/issues/18

## How was this PR tested?

The component_container_callback_isolated and the thread configurator worked correctly for https://github.com/tier4/pilot-auto.xx1.solio/tree/expt-yano-beta/v0.48.

## Notes for reviewers
