### PR TITLE
fix dependency missing

### DIFF
--- a/cie_thread_configurator/package.xml
+++ b/cie_thread_configurator/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_lint_common</test_depend>
 
   <depend>rclcpp</depend>
+  <depend>yaml-cpp</depend>
 
   <depend>cie_config_msgs</depend>
 


### PR DESCRIPTION
## Description
Error in agnocast:
https://build.ros2.org/job/Hdev__agnocast__ubuntu_jammy_amd64/306/

But same in cie.

## Related links

## How was this PR tested?

## Notes for reviewers
