### PR TITLE
ci: add parallel-workers and merge-install options to colcon build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,6 +57,6 @@ jobs:
       if: steps.check_diff_cpp.outputs.cpp_changed == 'true'
       run: |
         source /opt/ros/humble/setup.bash
-        colcon build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+        colcon build --parallel-workers 1 --merge-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
     
     # TODO: run tests


### PR DESCRIPTION
## Summary
- Add `--parallel-workers 1` and `--merge-install` options to colcon build command in CI workflow

## Reference
- https://github.com/tier4/agnocast/pull/936