### PR TITLE
Remove unnecessary sleep from publish_callback_group_info

### DIFF
--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -83,7 +83,6 @@ void publish_callback_group_info(
   message->callback_group_id = callback_group_id;
 
   publisher->publish(*message);
-  rclcpp::sleep_for(std::chrono::milliseconds(500));
 }
 
 std::map<std::string, std::string> get_hardware_info() {


### PR DESCRIPTION
Ported from https://github.com/tier4/agnocast/pull/989.