### PR TITLE
docs: add comparison table of real-time executors

### DIFF
--- a/docs/comparison_with_other_executors.md
+++ b/docs/comparison_with_other_executors.md
@@ -45,7 +45,7 @@ If the Executor has been merged into the ROS 2 mainline, or can be introduced wi
 | Ros-RT [9]                                     | ✔                 | ✔                     | ✔                     | ✔                | ✔                              |                |
 | CallbackIsolatedExecutor [10]                  | ✔\*1              | ✔                     | ✔                     | ✔                | ✔                              | ✔              |
 
-**\*1**: The ready queue is updated each time a thread selects a callback to execute.
+\*1: The ready queue is updated each time a thread selects a callback to execute.
 
 ---
 


### PR DESCRIPTION
## Description

Add a document comparing CallbackIsolatedExecutor with other ROS 2 executors from the real-time performance perspective.

The comparison covers six criteria: Immediate Enqueue, Per-Callback Priority, Non-Nested Scheduling, Fully Preemptive, Support for Reentrant Callbacks, and ROS 2 Mainline compatibility, across 10 executors from academic literature.

## Related links

## How was this PR tested?

## Notes for reviewers

This is a documentation-only change. No code modifications.