### PR TITLE
docs: clarify ROS 2 mainline criterion description

### DIFF
--- a/docs/comparison_with_other_executors.md
+++ b/docs/comparison_with_other_executors.md
@@ -25,7 +25,7 @@ If, when a callback becomes ready while it is executing, it can be properly enqu
 
 **ROS 2 Mainline**
 
-If the Executor has been merged into the ROS 2 mainline, or can be introduced without modifying the ROS 2 implementation, ✔ is marked.
+If the Executor has been merged into the ROS 2 mainline, or can be used by simply installing a standalone package without requiring changes to rcl or rclcpp, ✔ is marked.
 
 ---
 


### PR DESCRIPTION
## Description

Clarify the "ROS 2 Mainline" criterion in the executor comparison table. The previous wording ("can be introduced without modifying the ROS 2 implementation") was ambiguous. The updated wording explicitly states that ✔ is marked when the executor can be used by simply installing a standalone package without requiring changes to rcl or rclcpp.

## Related links

## How was this PR tested?

## Notes for reviewers

Documentation-only change — single sentence rewording for clarity.