### PR TITLE
fix(thread_configurator): apply scheduling to all reentrant callback group threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,8 @@ After successful validation, the configurator will print the settings and then w
 In this state, when you launch the target ROS 2 application, the configurator node will receive callback group information from the application.
 The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application.
 
-If your configuration file contains callback groups with the `SCHED_DEADLINE` policy, the configurator node's window will display the message `Apply sched deadline?` and wait as shown below. If no `SCHED_DEADLINE` configurations are present, this prompt will be skipped automatically.
-
-<img width="1346" height="160" alt="cie_image2" src="https://github.com/user-attachments/assets/934ab8d5-4894-4549-aa57-d9e7ef8f22c9" />
-
-At this stage, settings with policies other than `SCHED_DEADLINE` have already been applied, while the application of settings including the `SCHED_DEADLINE` policy is postponed.
-To apply settings that include the `SCHED_DEADLINE` policy, press the enter key in the window where `Apply sched deadline?` is displayed.
+Settings with policies other than `SCHED_DEADLINE` are applied immediately as each callback group is received.
+Once all callback groups have been registered, `SCHED_DEADLINE` settings are automatically applied together.
 
 <details>
 <summary>Why delayed configuration of the SCHED_DEADLINE policy?</summary>
@@ -268,11 +264,9 @@ Therefore, applying the `SCHED_DEADLINE` policy after the system has started, su
 You need to apply the `SCHED_DEADLINE` policy only after the system has fully started up and no further creation of new child threads is expected.
 </details>
 
-<img width="1348" height="223" alt="cie_image3" src="https://github.com/user-attachments/assets/0ce5f16c-af94-4d0e-976d-a09604c14367" />
-
-While the target ROS 2 application is running, the configurator node's window should not be closed and must remain open.
-After the execution of the target ROS 2 application has ended, press the enter key in the window displaying `Press enter to exit and remove cgroups...`.
-This will terminate the execution of the configurator node and simultaneously delete the cgroup that was created for setting the affinity of tasks with the `SCHED_DEADLINE` policy.
+The configurator node runs persistently and will automatically re-apply configurations if the target ROS 2 application is restarted.
+To terminate the configurator node, press Ctrl+C.
+If `SCHED_DEADLINE` policies were used, the cgroups created for affinity settings will be cleaned up automatically on exit.
 
 ## Notes on Adoption
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ You need to apply the `SCHED_DEADLINE` policy only after the system has fully st
 
 The configurator node runs persistently and will automatically re-apply configurations if the target ROS 2 application is restarted.
 To terminate the configurator node, press Ctrl+C.
-If `SCHED_DEADLINE` policies were used, the configurator node will attempt to remove the cpuset cgroups it created for affinity settings when it exits. This cleanup will only succeed if the target application has already stopped and no threads remain attached to those cgroups; otherwise, you may need to stop the application first and/or remove the remaining cgroups manually.
+If `SCHED_DEADLINE` policies were used, the cgroups created for affinity settings will be cleaned up automatically on exit.
 
 ## Notes on Adoption
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ You need to apply the `SCHED_DEADLINE` policy only after the system has fully st
 
 The configurator node runs persistently and will automatically re-apply configurations if the target ROS 2 application is restarted.
 To terminate the configurator node, press Ctrl+C.
-If `SCHED_DEADLINE` policies were used, the cgroups created for affinity settings will be cleaned up automatically on exit.
+If `SCHED_DEADLINE` policies were used, the configurator node will attempt to remove the cpuset cgroups it created for affinity settings when it exits. This cleanup will only succeed if the target application has already stopped and no threads remain attached to those cgroups; otherwise, you may need to stop the application first and/or remove the remaining cgroups manually.
 
 ## Notes on Adoption
 

--- a/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
@@ -26,13 +26,10 @@ class ThreadConfiguratorNode : public rclcpp::Node {
   };
 
 public:
-  ThreadConfiguratorNode(const YAML::Node &yaml);
+  explicit ThreadConfiguratorNode(const YAML::Node &yaml);
   ~ThreadConfiguratorNode();
-  bool all_applied();
   void print_all_unapplied();
-
-  bool exist_deadline_config();
-  bool apply_deadline_configs();
+  bool has_configured_once() const;
 
 private:
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> &cpus);
@@ -41,6 +38,7 @@ private:
       const cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(
       const cie_config_msgs::msg::NonRosThreadInfo::SharedPtr msg);
+  void apply_deadline_configs();
 
   rclcpp::Subscription<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr
       subscription_;
@@ -51,6 +49,7 @@ private:
   std::unordered_map<std::string, ThreadConfig *> id_to_thread_config_;
   int unapplied_num_;
   int cgroup_num_;
+  bool configured_at_least_once_ = false;
 
-  std::vector<ThreadConfig *> deadline_configs_;
+  std::vector<ThreadConfig> deadline_configs_;
 };

--- a/cie_thread_configurator/src/main.cpp
+++ b/cie_thread_configurator/src/main.cpp
@@ -80,26 +80,9 @@ static void spin_thread_configurator_node(const std::string &config_filename) {
 
   executor->add_node(node);
 
-  while (rclcpp::ok() && !node->all_applied()) {
-    executor->spin_once();
-  }
+  executor->spin();
 
-  if (node->all_applied()) {
-    if (node->exist_deadline_config()) {
-      RCLCPP_INFO(node->get_logger(), "Apply sched deadline?");
-      std::cin.get();
-
-      node->apply_deadline_configs();
-
-      RCLCPP_INFO(node->get_logger(),
-                  "Success: All of the configurations are applied."
-                  "\nPress enter to exit and remove cgroups, if there are "
-                  "SCHED_DEADLINE tasks:");
-      std::cin.get();
-    }
-    RCLCPP_INFO(node->get_logger(),
-                "Success: All of the configurations are applied.");
-  } else {
+  if (!node->has_configured_once()) {
     node->print_all_unapplied();
   }
 }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -100,8 +100,6 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode() {
   }
 }
 
-bool ThreadConfiguratorNode::all_applied() { return unapplied_num_ == 0; }
-
 void ThreadConfiguratorNode::print_all_unapplied() {
   RCLCPP_WARN(this->get_logger(), "Following threads are not yet configured");
 
@@ -110,6 +108,10 @@ void ThreadConfiguratorNode::print_all_unapplied() {
       RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
     }
   }
+}
+
+bool ThreadConfiguratorNode::has_configured_once() const {
+  return configured_at_least_once_;
 }
 
 bool ThreadConfiguratorNode::set_affinity_by_cgroup(
@@ -250,11 +252,20 @@ void ThreadConfiguratorNode::callback_group_callback(
 
   ThreadConfig *config = it->second;
   if (config->applied) {
+    if (config->thread_id == msg->thread_id) {
+      RCLCPP_INFO(
+          this->get_logger(),
+          "This callback group is already configured. skip (id=%s, tid=%ld)",
+          msg->callback_group_id.c_str(), msg->thread_id);
+      return;
+    }
     RCLCPP_INFO(
         this->get_logger(),
-        "This callback group is already configured. skip (id=%s, tid=%ld)",
-        msg->callback_group_id.c_str(), msg->thread_id);
-    return;
+        "Detected a new thread for an already-configured callback group. "
+        "This is expected when the application was restarted or the group "
+        "is Reentrant with multiple threads. Applying configuration "
+        "(id=%s, old_tid=%ld, new_tid=%ld)",
+        msg->callback_group_id.c_str(), config->thread_id, msg->thread_id);
   }
 
   RCLCPP_INFO(this->get_logger(), "Received CallbackGroupInfo: tid=%ld | %s",
@@ -262,16 +273,26 @@ void ThreadConfiguratorNode::callback_group_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    // delayed applying
-    deadline_configs_.push_back(config);
+    // Store a copy so that each thread_id is preserved independently
+    deadline_configs_.push_back(*config);
   } else {
-    bool success = issue_syscalls(*config);
-    if (!success)
+    if (!issue_syscalls(*config)) {
+      RCLCPP_WARN(this->get_logger(),
+                  "Skipping configuration for callback group (id=%s, tid=%ld) "
+                  "due to syscall failure.",
+                  msg->callback_group_id.c_str(), msg->thread_id);
       return;
+    }
   }
 
-  config->applied = true;
-  unapplied_num_--;
+  if (!config->applied) {
+    unapplied_num_--;
+    config->applied = true;
+  }
+
+  if (unapplied_num_ == 0) {
+    apply_deadline_configs();
+  }
 }
 
 void ThreadConfiguratorNode::non_ros_thread_callback(
@@ -287,10 +308,18 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 
   ThreadConfig *config = it->second;
   if (config->applied) {
+    if (config->thread_id == msg->thread_id) {
+      RCLCPP_INFO(
+          this->get_logger(),
+          "This non-ROS thread is already configured. skip (name=%s, tid=%ld)",
+          msg->thread_name.c_str(), msg->thread_id);
+      return;
+    }
     RCLCPP_INFO(this->get_logger(),
-                "This thread is already configured. skip (name=%s, tid=%ld)",
-                msg->thread_name.c_str(), msg->thread_id);
-    return;
+                "This non-ROS thread is already configured, but thread_id "
+                "changed. Re-applying configuration (name=%s, old_tid=%ld, "
+                "new_tid=%ld)",
+                msg->thread_name.c_str(), config->thread_id, msg->thread_id);
   }
 
   RCLCPP_INFO(this->get_logger(), "Received NonRosThreadInfo: tid=%ld | %s",
@@ -298,27 +327,46 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    // delayed applying
-    deadline_configs_.push_back(config);
+    // Store a copy so that each thread_id is preserved independently
+    deadline_configs_.push_back(*config);
   } else {
-    bool success = issue_syscalls(*config);
-    if (!success)
+    if (!issue_syscalls(*config)) {
+      RCLCPP_WARN(this->get_logger(),
+                  "Skipping configuration for non-ROS thread (name=%s, "
+                  "tid=%ld) due to syscall failure.",
+                  msg->thread_name.c_str(), msg->thread_id);
       return;
+    }
   }
 
+  if (!config->applied) {
+    unapplied_num_--;
+  }
   config->applied = true;
-  unapplied_num_--;
-}
 
-bool ThreadConfiguratorNode::apply_deadline_configs() {
-  for (auto config : deadline_configs_) {
-    if (!issue_syscalls(*config))
-      return false;
+  if (unapplied_num_ == 0) {
+    apply_deadline_configs();
   }
-
-  return true;
 }
 
-bool ThreadConfiguratorNode::exist_deadline_config() {
-  return !deadline_configs_.empty();
+void ThreadConfiguratorNode::apply_deadline_configs() {
+  for (const auto &config : deadline_configs_) {
+    if (!issue_syscalls(config)) {
+      RCLCPP_WARN(this->get_logger(),
+                  "Failed to apply SCHED_DEADLINE for tid=%ld",
+                  config.thread_id);
+    }
+  }
+  deadline_configs_.clear();
+
+  RCLCPP_INFO(this->get_logger(),
+              "Success: All of the configurations are applied.");
+
+  configured_at_least_once_ = true;
+
+  // Reset for re-application when target applications restart
+  unapplied_num_ = thread_configs_.size();
+  for (auto &config : thread_configs_) {
+    config.applied = false;
+  }
 }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -273,19 +273,8 @@ void ThreadConfiguratorNode::callback_group_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    if (configured_at_least_once_) {
-      // After first cycle, apply SCHED_DEADLINE immediately to avoid
-      // late-arriving reentrant threads being stuck waiting for a new cycle
-      if (!issue_syscalls(*config)) {
-        RCLCPP_WARN(this->get_logger(),
-                    "Failed to apply SCHED_DEADLINE for callback group "
-                    "(id=%s, tid=%ld)",
-                    msg->callback_group_id.c_str(), msg->thread_id);
-      }
-    } else {
-      // Store a copy so that each thread_id is preserved independently
-      deadline_configs_.push_back(*config);
-    }
+    // Store a copy so that each thread_id is preserved independently
+    deadline_configs_.push_back(*config);
   } else {
     if (!issue_syscalls(*config)) {
       RCLCPP_WARN(this->get_logger(),
@@ -338,19 +327,8 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    if (configured_at_least_once_) {
-      // After first cycle, apply SCHED_DEADLINE immediately to avoid
-      // late-arriving threads being stuck waiting for a new cycle
-      if (!issue_syscalls(*config)) {
-        RCLCPP_WARN(this->get_logger(),
-                    "Failed to apply SCHED_DEADLINE for non-ROS thread "
-                    "(name=%s, tid=%ld)",
-                    msg->thread_name.c_str(), msg->thread_id);
-      }
-    } else {
-      // Store a copy so that each thread_id is preserved independently
-      deadline_configs_.push_back(*config);
-    }
+    // Store a copy so that each thread_id is preserved independently
+    deadline_configs_.push_back(*config);
   } else {
     if (!issue_syscalls(*config)) {
       RCLCPP_WARN(this->get_logger(),
@@ -372,25 +350,17 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 }
 
 void ThreadConfiguratorNode::apply_deadline_configs() {
-  bool all_succeeded = true;
   for (const auto &config : deadline_configs_) {
     if (!issue_syscalls(config)) {
       RCLCPP_WARN(this->get_logger(),
                   "Failed to apply SCHED_DEADLINE for tid=%ld",
                   config.thread_id);
-      all_succeeded = false;
     }
   }
   deadline_configs_.clear();
 
-  if (all_succeeded) {
-    RCLCPP_INFO(this->get_logger(),
-                "Success: All of the configurations are applied.");
-  } else {
-    RCLCPP_WARN(this->get_logger(),
-                "Some SCHED_DEADLINE configurations failed to apply. "
-                "Non-deadline configurations were applied successfully.");
-  }
+  RCLCPP_INFO(this->get_logger(),
+              "Success: All of the configurations are applied.");
 
   configured_at_least_once_ = true;
 

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -273,8 +273,19 @@ void ThreadConfiguratorNode::callback_group_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    // Store a copy so that each thread_id is preserved independently
-    deadline_configs_.push_back(*config);
+    if (configured_at_least_once_) {
+      // After first cycle, apply SCHED_DEADLINE immediately to avoid
+      // late-arriving reentrant threads being stuck waiting for a new cycle
+      if (!issue_syscalls(*config)) {
+        RCLCPP_WARN(this->get_logger(),
+                    "Failed to apply SCHED_DEADLINE for callback group "
+                    "(id=%s, tid=%ld)",
+                    msg->callback_group_id.c_str(), msg->thread_id);
+      }
+    } else {
+      // Store a copy so that each thread_id is preserved independently
+      deadline_configs_.push_back(*config);
+    }
   } else {
     if (!issue_syscalls(*config)) {
       RCLCPP_WARN(this->get_logger(),
@@ -327,8 +338,19 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   config->thread_id = msg->thread_id;
 
   if (config->policy == "SCHED_DEADLINE") {
-    // Store a copy so that each thread_id is preserved independently
-    deadline_configs_.push_back(*config);
+    if (configured_at_least_once_) {
+      // After first cycle, apply SCHED_DEADLINE immediately to avoid
+      // late-arriving threads being stuck waiting for a new cycle
+      if (!issue_syscalls(*config)) {
+        RCLCPP_WARN(this->get_logger(),
+                    "Failed to apply SCHED_DEADLINE for non-ROS thread "
+                    "(name=%s, tid=%ld)",
+                    msg->thread_name.c_str(), msg->thread_id);
+      }
+    } else {
+      // Store a copy so that each thread_id is preserved independently
+      deadline_configs_.push_back(*config);
+    }
   } else {
     if (!issue_syscalls(*config)) {
       RCLCPP_WARN(this->get_logger(),
@@ -350,17 +372,25 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 }
 
 void ThreadConfiguratorNode::apply_deadline_configs() {
+  bool all_succeeded = true;
   for (const auto &config : deadline_configs_) {
     if (!issue_syscalls(config)) {
       RCLCPP_WARN(this->get_logger(),
                   "Failed to apply SCHED_DEADLINE for tid=%ld",
                   config.thread_id);
+      all_succeeded = false;
     }
   }
   deadline_configs_.clear();
 
-  RCLCPP_INFO(this->get_logger(),
-              "Success: All of the configurations are applied.");
+  if (all_succeeded) {
+    RCLCPP_INFO(this->get_logger(),
+                "Success: All of the configurations are applied.");
+  } else {
+    RCLCPP_WARN(this->get_logger(),
+                "Some SCHED_DEADLINE configurations failed to apply. "
+                "Non-deadline configurations were applied successfully.");
+  }
 
   configured_at_least_once_ = true;
 


### PR DESCRIPTION
## Description

Previously, `ThreadConfiguratorNode` had two issues with reentrant callback groups:

1. **Only the first thread was configured**: Reentrant callback groups spawn multiple threads sharing the same `callback_group_id`. The node skipped subsequent threads as "already configured".
2. **No re-application on app restart**: Once all configs were applied, the node exited. Restarting the target application required restarting the configurator too.

This PR fixes both by:
- Distinguishing between duplicate messages (same `thread_id` → skip) and new threads (different `thread_id` → re-apply)
- Making the node persistent via `executor->spin()` with automatic state reset after all configs are applied
- Storing `SCHED_DEADLINE` configs by value (not pointer) so each thread's `tid` is preserved independently
- Automatically applying `SCHED_DEADLINE` configs when `unapplied_num_` reaches 0, removing the interactive `stdin` prompt

## Related links

## How was this PR tested?

Ran `thread_configurator_node` with a YAML config (SCHED_OTHER, nice=5) alongside `reentrant_node_main` (4 reentrant threads). Verified:
- All 4 threads received the configuration (1 initial + 3 re-applied via "Detected a new thread" log)
- `nice` values confirmed via `/proc/<tid>/stat` for all threads
- Re-application after app restart works (second run also gets configured)
- Mandatory reentrant verification passed (Timer1: ~90-100, Timer2: ~9-10, TIDs: >=2)

## Notes for reviewers

### Thread configurator behavior changes
