### PR TITLE
fix(cie): prevent duplicate node name by setting use_global_arguments(false)

### DIFF
--- a/callback_isolated_executor/src/component_container_callback_isolated.cpp
+++ b/callback_isolated_executor/src/component_container_callback_isolated.cpp
@@ -31,10 +31,7 @@ public:
   template <typename... Args>
   ComponentManagerCallbackIsolated(Args &&...args)
       : rclcpp_components::ComponentManager(std::forward<Args>(args)...) {
-    client_publisher_ =
-        create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
-            "/cie_thread_configurator/callback_group_info",
-            rclcpp::QoS(1000).keep_all());
+    client_publisher_ = cie_thread_configurator::create_client_publisher();
 
     // Declare and get parameters for MultiThreadedExecutorInternal
     auto reentrant_parallelism_param =

--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include <array>
 #include <chrono>
 #include <functional>
@@ -62,10 +64,13 @@ std::string create_callback_group_id(rclcpp::CallbackGroup::SharedPtr group,
 
 rclcpp::Publisher<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr
 create_client_publisher() {
-  static int idx = 1;
-
-  auto node = std::make_shared<rclcpp::Node>(
-      "client_node" + std::to_string(idx++), "/cie_thread_configurator");
+  rclcpp::NodeOptions options;
+  // Disable global arguments so that global "__node" remapping cannot override
+  // this name and cause duplicate node names for these per-client nodes.
+  options.use_global_arguments(false);
+  auto node =
+      std::make_shared<rclcpp::Node>("client_node_" + std::to_string(getpid()),
+                                     "/cie_thread_configurator", options);
   auto publisher =
       node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info",


### PR DESCRIPTION
## Description

Port the fix from https://github.com/autowarefoundation/agnocast/pull/1082 to this repository.

- Set `use_global_arguments(false)` in `create_client_publisher()` so the internal CIE client node ignores global `__node` remapping arguments (e.g. `__node:=cie_listener_container`) and keeps its intended name.
- Use PID-based node name suffix (`client_node_<PID>`) instead of a static counter to ensure uniqueness across processes.
- Refactor `ComponentManagerCallbackIsolated` to use `create_client_publisher()` instead of creating its own publisher directly, so the same fix applies to the component container path.

## Related links

- https://github.com/autowarefoundation/agnocast/pull/1082

## How was this PR tested?

- [x] sample application (`sample_node_main`, `reentrant_node_main`, `sample_non_ros_process`)
- [x] component container launch (`sample_node.launch.xml`)

## Notes for reviewers

The corresponding agnocast PR also adds `use_global_arguments` support to `agnocast::NodeBase` and applies it to `create_agnocast_client_publisher()`, but those changes are in agnocastlib and not applicable to this repository.