### PR TITLE
fix: guard sched_attr definition to prevent redefinition with glibc 2.42

### DIFF
--- a/cie_thread_configurator/include/cie_thread_configurator/sched_deadline.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/sched_deadline.hpp
@@ -4,6 +4,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 
+#ifndef SCHED_ATTR_SIZE_VER1
 struct sched_attr {
   uint32_t size;
 
@@ -21,6 +22,7 @@ struct sched_attr {
   uint64_t sched_deadline;
   uint64_t sched_period;
 };
+#endif
 
 int sched_setattr(pid_t pid, const struct sched_attr *attr,
                   unsigned int flags) {


### PR DESCRIPTION
## Description

Add `#ifndef SCHED_ATTR_SIZE_VER1` / `#endif` guard around the `struct sched_attr` definition in `sched_deadline.hpp` to prevent redefinition errors when building with glibc 2.42+, which now provides its own `sched_attr` definition.

This is the equivalent of autowarefoundation/agnocast#1190.

## Related links

- https://github.com/autowarefoundation/agnocast/pull/1190

## How was this PR tested?

- Full `colcon build` succeeded
- `sample_node_main` ran correctly (distinct TIDs, correct timer frequencies)

## Notes for reviewers

Minimal change — only adds preprocessor guards. No functional change on older glibc versions.