### PR TITLE
feat(cie): align QoS settings with agnocast cie_thread_configurator

### DIFF
--- a/callback_isolated_executor/src/component_container_single.cpp
+++ b/callback_isolated_executor/src/component_container_single.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
   auto config_publisher =
       node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(1000).keep_all());
+          rclcpp::QoS(5000).keep_all().reliable().transient_local());
   auto tid = syscall(SYS_gettid);
 
   // dirty

--- a/callback_isolated_executor/src/component_container_single.cpp
+++ b/callback_isolated_executor/src/component_container_single.cpp
@@ -25,10 +25,7 @@ int main(int argc, char *argv[]) {
   auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
   exec->add_node(node);
 
-  auto config_publisher =
-      node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
-          "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(5000).keep_all().reliable().transient_local());
+  auto config_publisher = cie_thread_configurator::create_client_publisher();
   auto tid = syscall(SYS_gettid);
 
   // dirty

--- a/cie_thread_configurator/include/cie_thread_configurator/cie_thread_configurator.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/cie_thread_configurator.hpp
@@ -58,7 +58,7 @@ std::thread spawn_non_ros2_thread(const char *thread_name, F &&f,
     auto publisher =
         node->create_publisher<cie_config_msgs::msg::NonRosThreadInfo>(
             "/cie_thread_configurator/non_ros_thread_info",
-            rclcpp::QoS(1000).reliable());
+            rclcpp::QoS(5000).reliable());
     auto tid = static_cast<pid_t>(syscall(SYS_gettid));
 
     // Wait for subscriber to connect before publishing (timeout: 1 second)

--- a/cie_thread_configurator/src/prerun_node.cpp
+++ b/cie_thread_configurator/src/prerun_node.cpp
@@ -12,20 +12,16 @@
 #include "cie_thread_configurator/prerun_node.hpp"
 
 PrerunNode::PrerunNode() : Node("prerun_node") {
-  auto cbg_qos = rclcpp::QoS(rclcpp::QoSInitialization(
-                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
-                     .reliable()
-                     .transient_local();
+  auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
   subscription_ =
       this->create_subscription<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info", cbg_qos,
           std::bind(&PrerunNode::callback_group_callback, this,
                     std::placeholders::_1));
 
-  auto non_ros_thread_qos =
-      rclcpp::QoS(
-          rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
-          .reliable();
+  // volatile: publisher context in spawn_non_ros2_thread is destroyed after
+  // publish, so transient_local is ineffective.
+  auto non_ros_thread_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable();
   non_ros_thread_subscription_ =
       this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(
           "/cie_thread_configurator/non_ros_thread_info", non_ros_thread_qos,

--- a/cie_thread_configurator/src/prerun_node.cpp
+++ b/cie_thread_configurator/src/prerun_node.cpp
@@ -14,7 +14,8 @@
 PrerunNode::PrerunNode() : Node("prerun_node") {
   subscription_ =
       this->create_subscription<cie_config_msgs::msg::CallbackGroupInfo>(
-          "/cie_thread_configurator/callback_group_info", 100,
+          "/cie_thread_configurator/callback_group_info",
+          rclcpp::QoS(100).reliable().transient_local(),
           std::bind(&PrerunNode::callback_group_callback, this,
                     std::placeholders::_1));
 

--- a/cie_thread_configurator/src/prerun_node.cpp
+++ b/cie_thread_configurator/src/prerun_node.cpp
@@ -12,16 +12,23 @@
 #include "cie_thread_configurator/prerun_node.hpp"
 
 PrerunNode::PrerunNode() : Node("prerun_node") {
+  auto cbg_qos = rclcpp::QoS(rclcpp::QoSInitialization(
+                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
+                     .reliable()
+                     .transient_local();
   subscription_ =
       this->create_subscription<cie_config_msgs::msg::CallbackGroupInfo>(
-          "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(100).reliable().transient_local(),
+          "/cie_thread_configurator/callback_group_info", cbg_qos,
           std::bind(&PrerunNode::callback_group_callback, this,
                     std::placeholders::_1));
 
+  auto non_ros_thread_qos =
+      rclcpp::QoS(
+          rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
+          .reliable();
   non_ros_thread_subscription_ =
       this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(
-          "/cie_thread_configurator/non_ros_thread_info", 100,
+          "/cie_thread_configurator/non_ros_thread_info", non_ros_thread_qos,
           std::bind(&PrerunNode::non_ros_thread_callback, this,
                     std::placeholders::_1));
 }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -77,7 +77,7 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml)
   }
 
   auto cbg_qos = rclcpp::QoS(rclcpp::QoSInitialization(
-                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000))
+                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
                      .reliable()
                      .transient_local();
   subscription_ =
@@ -86,12 +86,13 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml)
           std::bind(&ThreadConfiguratorNode::callback_group_callback, this,
                     std::placeholders::_1));
 
-  auto non_ros_qos = rclcpp::QoS(rclcpp::QoSInitialization(
-                                     RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000))
-                         .reliable();
+  auto non_ros_thread_qos =
+      rclcpp::QoS(
+          rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
+          .reliable();
   non_ros_thread_subscription_ =
       this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(
-          "/cie_thread_configurator/non_ros_thread_info", non_ros_qos,
+          "/cie_thread_configurator/non_ros_thread_info", non_ros_thread_qos,
           std::bind(&ThreadConfiguratorNode::non_ros_thread_callback, this,
                     std::placeholders::_1));
 }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -76,20 +76,16 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml)
     id_to_thread_config_[config.thread_str] = &config;
   }
 
-  auto cbg_qos = rclcpp::QoS(rclcpp::QoSInitialization(
-                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
-                     .reliable()
-                     .transient_local();
+  auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();
   subscription_ =
       this->create_subscription<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info", cbg_qos,
           std::bind(&ThreadConfiguratorNode::callback_group_callback, this,
                     std::placeholders::_1));
 
-  auto non_ros_thread_qos =
-      rclcpp::QoS(
-          rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
-          .reliable();
+  // volatile: publisher context in spawn_non_ros2_thread is destroyed after
+  // publish, so transient_local is ineffective.
+  auto non_ros_thread_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable();
   non_ros_thread_subscription_ =
       this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(
           "/cie_thread_configurator/non_ros_thread_info", non_ros_thread_qos,

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -76,18 +76,22 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node &yaml)
     id_to_thread_config_[config.thread_str] = &config;
   }
 
-  auto qos = rclcpp::QoS(rclcpp::QoSInitialization(
-                             RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000))
-                 .reliable();
+  auto cbg_qos = rclcpp::QoS(rclcpp::QoSInitialization(
+                                 RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000))
+                     .reliable()
+                     .transient_local();
   subscription_ =
       this->create_subscription<cie_config_msgs::msg::CallbackGroupInfo>(
-          "/cie_thread_configurator/callback_group_info", qos,
+          "/cie_thread_configurator/callback_group_info", cbg_qos,
           std::bind(&ThreadConfiguratorNode::callback_group_callback, this,
                     std::placeholders::_1));
 
+  auto non_ros_qos = rclcpp::QoS(rclcpp::QoSInitialization(
+                                     RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000))
+                         .reliable();
   non_ros_thread_subscription_ =
       this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(
-          "/cie_thread_configurator/non_ros_thread_info", qos,
+          "/cie_thread_configurator/non_ros_thread_info", non_ros_qos,
           std::bind(&ThreadConfiguratorNode::non_ros_thread_callback, this,
                     std::placeholders::_1));
 }

--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -74,7 +74,7 @@ create_client_publisher() {
   auto publisher =
       node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(5000).keep_all().reliable().transient_local());
+          rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local());
   return publisher;
 }
 

--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -74,7 +74,7 @@ create_client_publisher() {
   auto publisher =
       node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(1000).keep_all().transient_local());
+          rclcpp::QoS(5000).keep_all().reliable().transient_local());
   return publisher;
 }
 

--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -74,7 +74,7 @@ create_client_publisher() {
   auto publisher =
       node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
           "/cie_thread_configurator/callback_group_info",
-          rclcpp::QoS(1000).keep_all());
+          rclcpp::QoS(1000).keep_all().transient_local());
   return publisher;
 }
 
@@ -82,14 +82,6 @@ void publish_callback_group_info(
     const rclcpp::Publisher<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr
         &publisher,
     int64_t tid, const std::string &callback_group_id) {
-  if (publisher->get_subscription_count() == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("cie_thread_configurator"),
-                "No subscriber for CallbackGroupInfo. "
-                "Please run thread_configurator_node if you want to configure "
-                "thread scheduling.");
-    return;
-  }
-
   auto message = std::make_shared<cie_config_msgs::msg::CallbackGroupInfo>();
 
   message->thread_id = tid;


### PR DESCRIPTION
## Description

Port of https://github.com/autowarefoundation/agnocast/pull/1049 and https://github.com/autowarefoundation/agnocast/pull/1218.

Use Transient Local durability QoS for the `CallbackGroupInfo` topic so that `thread_configurator_node` (and `prerun_node`) can receive cached messages even when they start after the application nodes.

### CallbackGroupInfo

| Role | Location | History | Reliability | Durability |
|------|----------|---------|-------------|------------|
| Pub | `util.cpp` (`create_client_publisher`, used by `component_container_callback_isolated.cpp` and `component_container_single.cpp`) | keep_all | reliable | transient_local |
| Sub | `thread_configurator_node.cpp` | keep_all | reliable | transient_local |
| Sub | `prerun_node.cpp` | keep_all | reliable | transient_local |

### NonRosThreadInfo

| Role | Location | History | Reliability | Durability |
|------|----------|---------|-------------|------------|
| Pub | `cie_thread_configurator.hpp` (`spawn_non_ros2_thread`) | keep_last(5000) | reliable | volatile |
| Sub | `thread_configurator_node.cpp` | keep_all | reliable | volatile |
| Sub | `prerun_node.cpp` | keep_all | reliable | volatile |

> **Note:** `NonRosThreadInfo` uses volatile durability because the publisher context in `spawn_non_ros2_thread` is destroyed after publish, so transient_local would be ineffective.

## Related links

- https://github.com/autowarefoundation/agnocast/pull/1049
- https://github.com/autowarefoundation/agnocast/pull/1218

## How was this PR tested?

## Notes for reviewers