### PR TITLE
fix(cie): add missing export dependencies in cie_thread_configurator

### DIFF
--- a/cie_thread_configurator/CMakeLists.txt
+++ b/cie_thread_configurator/CMakeLists.txt
@@ -65,4 +65,5 @@ install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
+ament_export_dependencies(cie_config_msgs yaml-cpp rclcpp)
 ament_package()


### PR DESCRIPTION
## Description
`cie_thread_configurator` was missing `ament_export_dependencies` for `cie_config_msgs`, `yaml-cpp`, and `rclcpp`. These are all used in its public headers, so downstream packages that only depend on `cie_thread_configurator` could fail to build because the transitive dependencies were not found.

This is the same issue as autowarefoundation/agnocast#1254.

## Related links
- autowarefoundation/agnocast#1254

## How was this PR tested?

## Notes for reviewers