### PR TITLE
fix(cie): apply SCHED_DEADLINE immediately using SCHED_FLAG_RESET_ON_FORK

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The entries in the configurator window show the callback group ID and OS thread 
 While the target ROS 2 application is running, the configurator node's window should not be closed and must remain open.
 If your configuration includes `SCHED_DEADLINE` threads with CPU affinity (configured via cgroup), after all configurations are applied the configurator will display `Press enter to exit and remove cgroups...`.
 Press enter to terminate the configurator and clean up the cgroup directories.
-If no cgroup-based affinity was used, the configurator exits automatically once the target application finishes.
+If no cgroup-based affinity was used, the configurator exits automatically once all configurations have been applied (that is, after it receives the required thread information from the target application).
 
 ## Notes on Adoption
 

--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ In this state, when you launch the target ROS 2 application, the configurator no
 The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application, and all configured policies are applied immediately upon receipt.
 
 While the target ROS 2 application is running, the configurator node's window should not be closed and must remain open.
-After the execution of the target ROS 2 application has ended, press the enter key in the window displaying `Press enter to exit and remove cgroups...`.
-This will terminate the execution of the configurator node and simultaneously delete the cgroup that was created for setting the affinity of tasks with the `SCHED_DEADLINE` policy.
+If your configuration includes `SCHED_DEADLINE` threads with CPU affinity (configured via cgroup), after all configurations are applied the configurator will display `Press enter to exit and remove cgroups...`.
+Press enter to terminate the configurator and clean up the cgroup directories.
+If no cgroup-based affinity was used, the configurator exits automatically once the target application finishes.
 
 ## Notes on Adoption
 

--- a/README.md
+++ b/README.md
@@ -253,32 +253,7 @@ After successful validation, the configurator will print the settings and then w
 <img width="1292" height="366" alt="cie_image1" src="https://github.com/user-attachments/assets/537034e0-167d-40dd-83ad-72c6efba7af8" />
 
 In this state, when you launch the target ROS 2 application, the configurator node will receive callback group information from the application.
-The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application.
-
-If your configuration file contains callback groups with the `SCHED_DEADLINE` policy, the configurator node's window will display the message `Apply sched deadline?` and wait as shown below. If no `SCHED_DEADLINE` configurations are present, this prompt will be skipped automatically.
-
-<img width="1346" height="160" alt="cie_image2" src="https://github.com/user-attachments/assets/934ab8d5-4894-4549-aa57-d9e7ef8f22c9" />
-
-At this stage, settings with policies other than `SCHED_DEADLINE` have already been applied, while the application of settings including the `SCHED_DEADLINE` policy is postponed.
-To apply settings that include the `SCHED_DEADLINE` policy, press the enter key in the window where `Apply sched deadline?` is displayed.
-
-<details>
-<summary>Why delayed configuration of the SCHED_DEADLINE policy?</summary>
-
-We delay the applying of settings with the `SCHED_DEADLINE` policy because Autoware (main application area for this tool) contains nodes that implicitly create new threads immediately after startup, such as the EKF Localizer.
-Threads specified with the `SCHED_DEADLINE` policy are prohibited from creating new child tasks.
-Generally, real-time scheduling policies fail with an `EAGAIN` error when `clone(2)` is issued without the `SCHED_FLAG_RESET_ON_FORK` flag set.
-However, setting this flag for `SCHED_DEADLINE` threads is impossible due to the following facts:
-- According to [the Linux documentation for sched_setattr(2)](https://man7.org/linux/man-pages/man2/sched_setattr.2.html), the `flags` argument is currently required to be set to `0`, indicating that `SCHED_FLAG_RESET_ON_FORK` can only be set via `sched_setscheduler(2)`.
-- According to [the Linux documentation for sched_setscheduler(2)](https://man7.org/linux/man-pages/man2/sched_setscheduler.2.html), the `SCHED_DEADLINE` policy can only be set via `sched_setattr(2)` and not through `sched_setscheduler(2)`.
-
-Thus, we adopt a workaround where we delay only the settings that include the `SCHED_DEADLINE` policy.
-Autoware's EKF Localizer creates child threads immediately after starting and does not create more afterwards (these child threads are likely deleted soon after).
-Therefore, applying the `SCHED_DEADLINE` policy after the system has started, such as after starting playback of a rosbag or the operation of a real vehicle system, will not cause issues.
-You need to apply the `SCHED_DEADLINE` policy only after the system has fully started up and no further creation of new child threads is expected.
-</details>
-
-<img width="1348" height="223" alt="cie_image3" src="https://github.com/user-attachments/assets/0ce5f16c-af94-4d0e-976d-a09604c14367" />
+The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application, and all configured policies are applied immediately upon receipt.
 
 While the target ROS 2 application is running, the configurator node's window should not be closed and must remain open.
 After the execution of the target ROS 2 application has ended, press the enter key in the window displaying `Press enter to exit and remove cgroups...`.

--- a/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
@@ -38,8 +38,7 @@ public:
   bool all_applied();
   void print_all_unapplied();
 
-  bool exist_deadline_config();
-  bool apply_deadline_configs();
+  bool has_cgroup() const;
 
 private:
   void validate_hardware_info(const YAML::Node &yaml);
@@ -59,6 +58,4 @@ private:
   std::unordered_map<std::string, ThreadConfig *> id_to_thread_config_;
   int unapplied_num_;
   int cgroup_num_;
-
-  std::vector<ThreadConfig *> deadline_configs_;
 };

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -341,6 +341,7 @@ void ThreadConfiguratorNode::callback_group_callback(
                 "Skipping configuration for callback group (id=%s, tid=%ld) "
                 "due to syscall failure.",
                 msg->callback_group_id.c_str(), msg->thread_id);
+    return;
   }
 
   config->applied = true;
@@ -375,6 +376,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
                 "Skipping configuration for non-ROS thread (name=%s, tid=%ld) "
                 "due to syscall failure.",
                 msg->thread_name.c_str(), msg->thread_id);
+    return;
   }
 
   config->applied = true;

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -341,7 +341,6 @@ void ThreadConfiguratorNode::callback_group_callback(
                 "Skipping configuration for callback group (id=%s, tid=%ld) "
                 "due to syscall failure.",
                 msg->callback_group_id.c_str(), msg->thread_id);
-    return;
   }
 
   config->applied = true;
@@ -376,7 +375,6 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
                 "Skipping configuration for non-ROS thread (name=%s, tid=%ld) "
                 "due to syscall failure.",
                 msg->thread_name.c_str(), msg->thread_id);
-    return;
   }
 
   config->applied = true;

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -262,7 +262,12 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig &config) {
     struct sched_attr attr;
     memset(&attr, 0, sizeof(attr));
     attr.size = sizeof(attr);
-    attr.sched_flags = 0;
+    // SCHED_FLAG_RESET_ON_FORK lets the target thread still call
+    // fork(2)/clone(2) after being placed under SCHED_DEADLINE; without it,
+    // clone(2) returns EAGAIN. Children reset to SCHED_OTHER; each
+    // callback-group thread that needs its own SCHED_DEADLINE gets it via its
+    // own CallbackGroupInfo message.
+    attr.sched_flags = SCHED_FLAG_RESET_ON_FORK;
     attr.sched_nice = 0;
     attr.sched_priority = 0;
 
@@ -331,13 +336,12 @@ void ThreadConfiguratorNode::callback_group_callback(
               msg->thread_id, msg->callback_group_id.c_str());
   config->thread_id = msg->thread_id;
 
-  if (config->policy == "SCHED_DEADLINE") {
-    // delayed applying
-    deadline_configs_.push_back(config);
-  } else {
-    bool success = issue_syscalls(*config);
-    if (!success)
-      return;
+  if (!issue_syscalls(*config)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Skipping configuration for callback group (id=%s, tid=%ld) "
+                "due to syscall failure.",
+                msg->callback_group_id.c_str(), msg->thread_id);
+    return;
   }
 
   config->applied = true;
@@ -367,28 +371,16 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
               msg->thread_id, msg->thread_name.c_str());
   config->thread_id = msg->thread_id;
 
-  if (config->policy == "SCHED_DEADLINE") {
-    // delayed applying
-    deadline_configs_.push_back(config);
-  } else {
-    bool success = issue_syscalls(*config);
-    if (!success)
-      return;
+  if (!issue_syscalls(*config)) {
+    RCLCPP_WARN(this->get_logger(),
+                "Skipping configuration for non-ROS thread (name=%s, tid=%ld) "
+                "due to syscall failure.",
+                msg->thread_name.c_str(), msg->thread_id);
+    return;
   }
 
   config->applied = true;
   unapplied_num_--;
 }
 
-bool ThreadConfiguratorNode::apply_deadline_configs() {
-  for (auto config : deadline_configs_) {
-    if (!issue_syscalls(*config))
-      return false;
-  }
-
-  return true;
-}
-
-bool ThreadConfiguratorNode::exist_deadline_config() {
-  return !deadline_configs_.empty();
-}
+bool ThreadConfiguratorNode::has_cgroup() const { return cgroup_num_ > 0; }

--- a/cie_thread_configurator/src/thread_configurator_node_main.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node_main.cpp
@@ -21,19 +21,14 @@ int main(int argc, char *argv[]) {
     }
 
     if (node->all_applied()) {
-      if (node->exist_deadline_config()) {
-        RCLCPP_INFO(node->get_logger(), "Apply sched deadline?");
-        std::cin.get();
-
-        node->apply_deadline_configs();
-
+      RCLCPP_INFO(node->get_logger(),
+                  "Success: All of the configurations are applied.");
+      if (node->has_cgroup()) {
         RCLCPP_INFO(node->get_logger(),
                     "Press enter to exit and remove cgroups, if there are "
                     "SCHED_DEADLINE tasks:");
         std::cin.get();
       }
-      RCLCPP_INFO(node->get_logger(),
-                  "Success: All of the configurations are applied.");
     } else {
       node->print_all_unapplied();
     }

--- a/cie_thread_configurator/src/thread_configurator_node_main.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node_main.cpp
@@ -25,8 +25,8 @@ int main(int argc, char *argv[]) {
                   "Success: All of the configurations are applied.");
       if (node->has_cgroup()) {
         RCLCPP_INFO(node->get_logger(),
-                    "Press enter to exit and remove cgroups, if there are "
-                    "SCHED_DEADLINE tasks:");
+                    "Press enter to exit and remove the cgroups created for "
+                    "thread affinity:");
         std::cin.get();
       }
     } else {


### PR DESCRIPTION
## Description

Previously, `SCHED_DEADLINE` configurations were applied via a delayed, interactive workflow: the configurator waited for a user prompt ("Apply sched deadline?") before applying them. This was a workaround because `SCHED_DEADLINE` threads could not call `fork(2)`/`clone(2)` without triggering `EAGAIN`, which caused issues with nodes that spawn child threads at startup (e.g., EKF Localizer).

This PR eliminates the delayed application by setting `SCHED_FLAG_RESET_ON_FORK` in `sched_attr.sched_flags` for `SCHED_DEADLINE` threads. With this flag, children of `SCHED_DEADLINE` threads reset to `SCHED_OTHER`, allowing `fork`/`clone` to succeed. All scheduling policies, including `SCHED_DEADLINE`, are now applied immediately upon receiving callback group or non-ROS thread info.

Key changes:
- Set `SCHED_FLAG_RESET_ON_FORK` for `SCHED_DEADLINE` threads in `issue_syscalls()`
- Remove the `deadline_configs_` vector and delayed application logic
- Remove `exist_deadline_config()` and `apply_deadline_configs()` methods; add `has_cgroup() const`
- Remove the interactive "Apply sched deadline?" prompt from main; show success message immediately
- Add `RCLCPP_WARN` logs when syscall application fails for a thread
- Update README to reflect the simplified workflow (no more delayed SCHED_DEADLINE step)

## Related links

port from https://github.com/autowarefoundation/agnocast/pull/1248

## How was this PR tested?

## Notes for reviewers