### PR TITLE
fix(cie): always re-apply thread configuration and keep running

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,11 @@ After successful validation, the configurator will print the settings and then w
 <img width="1292" height="366" alt="cie_image1" src="https://github.com/user-attachments/assets/537034e0-167d-40dd-83ad-72c6efba7af8" />
 
 In this state, when you launch the target ROS 2 application, the configurator node will receive callback group information from the application.
-The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application, and all configured policies are applied immediately upon receipt.
+The entries in the configurator window show the callback group ID and OS thread ID information received from the ROS 2 application, and all configured policies are applied immediately upon receipt, including `SCHED_DEADLINE` (which uses `SCHED_FLAG_RESET_ON_FORK` so that forked children reset to `SCHED_OTHER`).
 
-While the target ROS 2 application is running, the configurator node's window should not be closed and must remain open.
-If your configuration includes `SCHED_DEADLINE` threads with CPU affinity (configured via cgroup), after all configurations are applied the configurator will display `Press enter to exit and remove cgroups...`.
-Press enter to terminate the configurator and clean up the cgroup directories.
-If no cgroup-based affinity was used, the configurator exits automatically once all configurations have been applied (that is, after it receives the required thread information from the target application).
+The configurator node keeps running after all configurations have been applied.
+This allows it to re-apply configurations automatically when a target application restarts (the OS may reuse thread IDs, so thread ID equality cannot be used to skip reconfiguration).
+If your configuration includes `SCHED_DEADLINE` threads with CPU affinity (configured via cgroup), the cgroup directories are cleaned up when the configurator node is terminated.
 
 ## Notes on Adoption
 

--- a/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
@@ -35,8 +35,8 @@ public:
   explicit ThreadConfiguratorNode(
       const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
   ~ThreadConfiguratorNode();
-  bool all_applied();
   void print_all_unapplied();
+  bool has_configured_once() const;
 
   bool has_cgroup() const;
 
@@ -48,6 +48,7 @@ private:
       const cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(
       const cie_config_msgs::msg::NonRosThreadInfo::SharedPtr msg);
+  void on_all_configured();
 
   rclcpp::Subscription<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr
       subscription_;
@@ -58,4 +59,5 @@ private:
   std::unordered_map<std::string, ThreadConfig *> id_to_thread_config_;
   int unapplied_num_;
   int cgroup_num_;
+  bool configured_at_least_once_ = false;
 };

--- a/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
@@ -36,7 +36,6 @@ public:
       const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
   ~ThreadConfiguratorNode();
   void print_all_unapplied();
-  bool has_configured_once() const;
 
   bool has_cgroup() const;
 

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -170,8 +170,6 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode() {
   }
 }
 
-bool ThreadConfiguratorNode::all_applied() { return unapplied_num_ == 0; }
-
 void ThreadConfiguratorNode::print_all_unapplied() {
   RCLCPP_WARN(this->get_logger(), "Following threads are not yet configured");
 
@@ -325,11 +323,14 @@ void ThreadConfiguratorNode::callback_group_callback(
 
   ThreadConfig *config = it->second;
   if (config->applied) {
+    // Always re-apply: the OS may reuse the same thread IDs after an
+    // application restarts, so we cannot use thread_id equality to skip
+    // reconfiguration.
     RCLCPP_INFO(
         this->get_logger(),
-        "This callback group is already configured. skip (id=%s, tid=%ld)",
+        "Re-applying configuration for already configured callback group "
+        "(id=%s, tid=%ld)",
         msg->callback_group_id.c_str(), msg->thread_id);
-    return;
   }
 
   RCLCPP_INFO(this->get_logger(), "Received CallbackGroupInfo: tid=%ld | %s",
@@ -344,8 +345,14 @@ void ThreadConfiguratorNode::callback_group_callback(
     return;
   }
 
+  if (!config->applied) {
+    unapplied_num_--;
+  }
   config->applied = true;
-  unapplied_num_--;
+
+  if (unapplied_num_ == 0) {
+    on_all_configured();
+  }
 }
 
 void ThreadConfiguratorNode::non_ros_thread_callback(
@@ -361,10 +368,14 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 
   ThreadConfig *config = it->second;
   if (config->applied) {
-    RCLCPP_INFO(this->get_logger(),
-                "This thread is already configured. skip (name=%s, tid=%ld)",
-                msg->thread_name.c_str(), msg->thread_id);
-    return;
+    // Always re-apply: the OS may reuse the same thread IDs after an
+    // application restarts, so we cannot use thread_id equality to skip
+    // reconfiguration.
+    RCLCPP_INFO(
+        this->get_logger(),
+        "Re-applying configuration for already configured non-ROS thread "
+        "(name=%s, tid=%ld)",
+        msg->thread_name.c_str(), msg->thread_id);
   }
 
   RCLCPP_INFO(this->get_logger(), "Received NonRosThreadInfo: tid=%ld | %s",
@@ -379,8 +390,25 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     return;
   }
 
+  if (!config->applied) {
+    unapplied_num_--;
+  }
   config->applied = true;
-  unapplied_num_--;
+
+  if (unapplied_num_ == 0) {
+    on_all_configured();
+  }
+}
+
+void ThreadConfiguratorNode::on_all_configured() {
+  RCLCPP_INFO(this->get_logger(),
+              "Success: All of the configurations are applied.");
+
+  configured_at_least_once_ = true;
+}
+
+bool ThreadConfiguratorNode::has_configured_once() const {
+  return configured_at_least_once_;
 }
 
 bool ThreadConfiguratorNode::has_cgroup() const { return cgroup_num_ > 0; }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -350,7 +350,7 @@ void ThreadConfiguratorNode::callback_group_callback(
   }
   config->applied = true;
 
-  if (unapplied_num_ == 0) {
+  if (unapplied_num_ == 0 && !configured_at_least_once_) {
     on_all_configured();
   }
 }
@@ -395,7 +395,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   }
   config->applied = true;
 
-  if (unapplied_num_ == 0) {
+  if (unapplied_num_ == 0 && !configured_at_least_once_) {
     on_all_configured();
   }
 }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -175,6 +175,10 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode() {
 }
 
 void ThreadConfiguratorNode::print_all_unapplied() {
+  if (unapplied_num_ == 0) {
+    return;
+  }
+
   RCLCPP_WARN(this->get_logger(), "Following threads are not yet configured");
 
   for (auto &config : thread_configs_) {
@@ -409,10 +413,6 @@ void ThreadConfiguratorNode::on_all_configured() {
               "Success: All of the configurations are applied.");
 
   configured_at_least_once_ = true;
-}
-
-bool ThreadConfiguratorNode::has_configured_once() const {
-  return configured_at_least_once_;
 }
 
 bool ThreadConfiguratorNode::has_cgroup() const { return cgroup_num_ > 0; }

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -119,6 +119,10 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(
           "/cie_thread_configurator/non_ros_thread_info", non_ros_thread_qos,
           std::bind(&ThreadConfiguratorNode::non_ros_thread_callback, this,
                     std::placeholders::_1));
+
+  if (unapplied_num_ == 0) {
+    on_all_configured();
+  }
 }
 
 void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node &yaml) {

--- a/cie_thread_configurator/src/thread_configurator_node_main.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node_main.cpp
@@ -15,21 +15,9 @@ int main(int argc, char *argv[]) {
         std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
     executor->add_node(node);
+    executor->spin();
 
-    while (rclcpp::ok() && !node->all_applied()) {
-      executor->spin_once();
-    }
-
-    if (node->all_applied()) {
-      RCLCPP_INFO(node->get_logger(),
-                  "Success: All of the configurations are applied.");
-      if (node->has_cgroup()) {
-        RCLCPP_INFO(node->get_logger(),
-                    "Press enter to exit and remove the cgroups created for "
-                    "thread affinity:");
-        std::cin.get();
-      }
-    } else {
+    if (!node->has_configured_once()) {
       node->print_all_unapplied();
     }
   } catch (const std::exception &e) {

--- a/cie_thread_configurator/src/thread_configurator_node_main.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node_main.cpp
@@ -17,9 +17,7 @@ int main(int argc, char *argv[]) {
     executor->add_node(node);
     executor->spin();
 
-    if (!node->has_configured_once()) {
-      node->print_all_unapplied();
-    }
+    node->print_all_unapplied();
   } catch (const std::exception &e) {
     std::cerr << "[ERROR] " << e.what() << std::endl;
     rclcpp::shutdown();


### PR DESCRIPTION
## Description

Port the "always re-apply" behavior from agnocast's `fix/thread-configurator-always-reapply` branch.

- The configurator now always re-applies scheduling configuration even for already-configured callback groups, handling the case where the OS reuses thread IDs after application restarts
- The configurator keeps running continuously via `executor->spin()` instead of exiting after all configurations are applied, enabling automatic re-configuration when target applications restart
- Removed `has_configured_once()` and moved the unapplied guard into `print_all_unapplied()` itself, so `main` always calls it unconditionally
- Updated README.md to reflect the new behavior (configurator stays running, SCHED_DEADLINE applied immediately with SCHED_FLAG_RESET_ON_FORK)

## Related links

- Upstream PR: https://github.com/autowarefoundation/agnocast/pull/1262
- close: https://github.com/autowarefoundation/callback_isolated_executor/issues/26

## How was this PR tested?

- [x] Build the package and verify compilation succeeds
- [x] Run thread_configurator_node with a sample application and verify all configurations are applied
- [x] Restart the target application and verify the configurator re-applies configurations automatically
- [x] Verify the configurator does not exit after initial configuration

## Notes for reviewers

The key behavioral changes are:
1. `callback_group_callback` and `non_ros_thread_callback` no longer early-return when `config->applied` is true — they always re-apply the configuration
2. `on_all_configured()` fires only once (guarded by `configured_at_least_once_`), and `unapplied_num_` is only decremented on the first apply
3. The main loop uses `executor->spin()` instead of `spin_once()` in a while loop, so the configurator node stays alive indefinitely
4. `has_configured_once()` / `all_applied()` removed; `print_all_unapplied()` now self-guards with an early return when `unapplied_num_ == 0`
5. The interactive "Press enter to exit" prompt for cgroup cleanup is removed; cgroups are now cleaned up in the destructor when the node is terminated