### PR TITLE
fix(cie): address misc code quality issues

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,9 +5,6 @@ on:
     types:
       - labeled
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   build-and-test:
     if: ${{ github.event.label.name == 'run-build-test' }}

--- a/cie_thread_configurator/include/cie_thread_configurator/sched_deadline.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/sched_deadline.hpp
@@ -24,7 +24,7 @@ struct sched_attr {
 };
 #endif
 
-int sched_setattr(pid_t pid, const struct sched_attr *attr,
-                  unsigned int flags) {
+inline int sched_setattr(pid_t pid, const struct sched_attr *attr,
+                         unsigned int flags) {
   return syscall(__NR_sched_setattr, pid, attr, flags);
 }

--- a/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
+++ b/cie_thread_configurator/include/cie_thread_configurator/thread_configurator_node.hpp
@@ -15,12 +15,12 @@ class ThreadConfiguratorNode : public rclcpp::Node {
     int64_t thread_id = -1;
     std::vector<int> affinity;
     std::string policy;
-    int priority;
+    int priority = 0;
 
     // For SCHED_DEADLINE
-    unsigned int runtime;
-    unsigned int period;
-    unsigned int deadline;
+    unsigned int runtime = 0;
+    unsigned int period = 0;
+    unsigned int deadline = 0;
 
     bool applied = false;
   };

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -197,8 +197,11 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
 
   std::string cpus_path = cgroup_path + "/cpuset.cpus";
   if (std::ofstream cpus_file{cpus_path}) {
-    for (int cpu : cpus)
-      cpus_file << cpu << ",";
+    for (size_t i = 0; i < cpus.size(); i++) {
+      if (i > 0)
+        cpus_file << ",";
+      cpus_file << cpus[i];
+    }
   } else {
     return false;
   }
@@ -288,6 +291,10 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig &config) {
           config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "Unknown scheduling policy '%s' for id=%s",
+                 config.policy.c_str(), config.thread_str.c_str());
+    return false;
   }
 
   if (config.affinity.size() > 0) {

--- a/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <error.h>
@@ -71,12 +72,22 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(
     return s;
   };
 
+  static const std::unordered_set<std::string> valid_policies = {
+      "SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE",
+      "SCHED_FIFO",  "SCHED_RR",    "SCHED_DEADLINE",
+  };
+
   // Common lambda to load thread configuration from YAML
   auto load_thread_config = [](ThreadConfig &config, const YAML::Node &node) {
     config.thread_str = node["id"].as<std::string>();
     for (auto &cpu : node["affinity"])
       config.affinity.push_back(cpu.as<int>());
     config.policy = node["policy"].as<std::string>();
+
+    if (valid_policies.find(config.policy) == valid_policies.end()) {
+      throw std::runtime_error("Unknown scheduling policy '" + config.policy +
+                               "' for id=" + config.thread_str);
+    }
 
     if (config.policy == "SCHED_DEADLINE") {
       config.runtime = node["runtime"].as<unsigned int>();
@@ -292,8 +303,9 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig &config) {
       return false;
     }
   } else {
-    RCLCPP_ERROR(this->get_logger(), "Unknown scheduling policy '%s' for id=%s",
-                 config.policy.c_str(), config.thread_str.c_str());
+    RCLCPP_ERROR(
+        this->get_logger(), "Unknown scheduling policy '%s' (id=%s, tid=%ld)",
+        config.policy.c_str(), config.thread_str.c_str(), config.thread_id);
     return false;
   }
 


### PR DESCRIPTION
## Description

Fix several code quality issues found during repository review:

- **Reject unknown scheduling policies:** `issue_syscalls()` now returns `false` and logs an error when an unrecognized policy string is encountered, instead of silently succeeding and only applying CPU affinity. Additionally, the policy string is validated at YAML load time so that typos (e.g. `SCHED_OTEHR`) cause an immediate `std::runtime_error` at startup rather than a deferred runtime failure.
- **Fix trailing comma in cpuset.cpus:** `set_affinity_by_cgroup()` now writes `"0,1,2"` instead of `"0,1,2,"` for canonical cpuset format.
- **Add `inline` to `sched_setattr()` in header:** Prevents ODR violation if `sched_deadline.hpp` is included from multiple translation units. Currently only one TU includes it, but the header is publicly installed.
- **Remove stale `CARGO_TERM_COLOR` env var:** Rust-specific environment variable copied into the C++ CI workflow.
- **Zero-initialize `ThreadConfig` members:** `priority`, `runtime`, `period`, and `deadline` now have default initializers to avoid uninitialized reads if access patterns change in the future.

## Related links

## How was this PR tested?

## Notes for reviewers