### PR TITLE
fix(cie): update checkout action and fix cancel_executor race

### DIFF
--- a/.github/workflows/run-pre-commit.yaml
+++ b/.github/workflows/run-pre-commit.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/callback_isolated_executor/src/component_container_callback_isolated.cpp
+++ b/callback_isolated_executor/src/component_container_callback_isolated.cpp
@@ -17,14 +17,13 @@ class ComponentManagerCallbackIsolated
 
   struct ExecutorWrapper {
     explicit ExecutorWrapper(std::shared_ptr<rclcpp::Executor> executor)
-        : executor(executor), thread_initialized(false) {}
+        : executor(executor) {}
 
     ExecutorWrapper(const ExecutorWrapper &) = delete;
     ExecutorWrapper &operator=(const ExecutorWrapper &) = delete;
 
     std::shared_ptr<rclcpp::Executor> executor;
     std::thread thread;
-    std::atomic_bool thread_initialized;
   };
 
 public:
@@ -176,7 +175,6 @@ void ComponentManagerCallbackIsolated::add_node_to_executor(uint64_t node_id) {
               }
             }
 
-            executor_wrapper.thread_initialized = true;
             executor_wrapper.executor->spin();
           });
     } else {
@@ -199,7 +197,6 @@ void ComponentManagerCallbackIsolated::add_node_to_executor(uint64_t node_id) {
                   this->client_publisher_, tid, group_id);
             }
 
-            executor_wrapper.thread_initialized = true;
             executor_wrapper.executor->spin();
           });
     }
@@ -221,12 +218,10 @@ void ComponentManagerCallbackIsolated::remove_node_from_executor(
 
 void ComponentManagerCallbackIsolated::cancel_executor(
     ExecutorWrapper &executor_wrapper) {
-  if (!executor_wrapper.thread_initialized) {
-    auto context = this->get_node_base_interface()->get_context();
+  auto context = this->get_node_base_interface()->get_context();
 
-    while (!executor_wrapper.executor->is_spinning() && rclcpp::ok(context)) {
-      rclcpp::sleep_for(std::chrono::milliseconds(1));
-    }
+  while (!executor_wrapper.executor->is_spinning() && rclcpp::ok(context)) {
+    rclcpp::sleep_for(std::chrono::milliseconds(1));
   }
 
   executor_wrapper.executor->cancel();

--- a/callback_isolated_executor/src/component_container_callback_isolated.cpp
+++ b/callback_isolated_executor/src/component_container_callback_isolated.cpp
@@ -218,6 +218,14 @@ void ComponentManagerCallbackIsolated::remove_node_from_executor(
 
 void ComponentManagerCallbackIsolated::cancel_executor(
     ExecutorWrapper &executor_wrapper) {
+  if (!executor_wrapper.thread.joinable()) {
+    return;
+  }
+
+  // Always wait for is_spinning() before cancel(). Do not use a separate
+  // "thread_initialized" flag as a fast-path: such a flag is set before spin()
+  // sets spinning=true, creating a window where cancel() has no effect and the
+  // subsequent spin() runs indefinitely, blocking join() forever.
   auto context = this->get_node_base_interface()->get_context();
 
   while (!executor_wrapper.executor->is_spinning() && rclcpp::ok(context)) {


### PR DESCRIPTION
## Description

Fix two issues found during repository-wide code review:

1. **CI: Update `actions/checkout` version** — `run-pre-commit.yaml` was using `actions/checkout@v2` (deprecated, Node.js 12-based) while `build-and-test.yaml` already uses `@v4`. Updated to `@v4` for consistency and security.

2. **Fix race condition in `cancel_executor`** — The `thread_initialized` flag was set to `true` before `spin()` internally sets `spinning=true`. If `cancel_executor` observed `thread_initialized==true` and skipped the `is_spinning()` wait, it could call `cancel()` (which sets `spinning=false`) before `spin()` set `spinning=true`. The subsequent `spin()` would override the cancellation and run indefinitely, blocking `thread.join()` forever.

   The fix:
   - Remove the `thread_initialized` fast-path and always wait for `is_spinning()` before calling `cancel()`.
   - Remove the `thread_initialized` field from `ExecutorWrapper` entirely.
   - Add a `joinable()` guard to avoid undefined behavior if the thread was never started (e.g., `std::thread` constructor threw).
   - Add an explanatory comment documenting why the unconditional `is_spinning()` wait is necessary, to prevent re-introduction of the fast-path optimization.

## Related links

## How was this PR tested?

## Notes for reviewers