### PR TITLE
test(cie): add minimal pub/sub launch_testing for CIE

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         set -e
         if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
-            | grep -qE '*\.(cpp|hpp)$'; then
+            | grep -qE '.*\.(cpp|hpp)$'; then
           echo "cpp_changed=true" >> $GITHUB_OUTPUT
         else
           echo "cpp_changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -79,7 +79,20 @@ jobs:
         source /opt/ros/${ROS_DISTRO}/setup.bash
         colcon build --parallel-workers 1 --merge-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
-    # TODO: run tests
+    - name: Test
+      if: steps.check_diff_cpp.outputs.cpp_changed == 'true'
+      run: |
+        source /opt/ros/${ROS_DISTRO}/setup.bash
+        source install/setup.bash
+        # Run only the functional launch test. Code style is enforced separately
+        # by the run-pre-commit workflow (clang-format), so the ament linters are
+        # excluded here via the launch_test label.
+        colcon test \
+          --packages-select callback_isolated_executor \
+          --merge-install \
+          --event-handlers console_direct+ \
+          --ctest-args -L launch_test
+        colcon test-result --verbose
 
   # Summary job that provides a single status check for branch protection rules.
   # Matrix jobs report status as "build-and-test-matrix (<distro>)", but branch protection

--- a/callback_isolated_executor/CMakeLists.txt
+++ b/callback_isolated_executor/CMakeLists.txt
@@ -65,4 +65,18 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
 ament_export_dependencies(cie_thread_configurator cie_config_msgs)
 
+if(BUILD_TESTING)
+  find_package(launch_testing_ament_cmake REQUIRED)
+
+  add_executable(cie_pubsub_test_node test/cie_pubsub_test_node.cpp)
+  target_link_libraries(cie_pubsub_test_node callback_isolated_executor)
+  ament_target_dependencies(cie_pubsub_test_node rclcpp std_msgs)
+
+  install(TARGETS cie_pubsub_test_node
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+
+  add_launch_test(test/test_cie_pubsub.launch.py)
+endif()
+
 ament_package()

--- a/callback_isolated_executor/package.xml
+++ b/callback_isolated_executor/package.xml
@@ -18,6 +18,9 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/callback_isolated_executor/test/cie_pubsub_test_node.cpp
+++ b/callback_isolated_executor/test/cie_pubsub_test_node.cpp
@@ -1,0 +1,71 @@
+#include <chrono>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int32.hpp"
+
+#include "callback_isolated_executor/callback_isolated_executor.hpp"
+
+using namespace std::chrono_literals;
+
+class TalkerNode : public rclcpp::Node {
+public:
+  TalkerNode() : Node("cie_test_talker"), count_(0) {
+    publisher_ = create_publisher<std_msgs::msg::Int32>("chatter", 10);
+    timer_group_ =
+        create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    timer_ = create_wall_timer(
+        100ms,
+        [this]() {
+          auto message = std_msgs::msg::Int32();
+          message.data = count_++;
+          publisher_->publish(message);
+        },
+        timer_group_);
+  }
+
+private:
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::CallbackGroup::SharedPtr timer_group_;
+  int32_t count_;
+};
+
+class ListenerNode : public rclcpp::Node {
+public:
+  ListenerNode() : Node("cie_test_listener") {
+    echo_publisher_ = create_publisher<std_msgs::msg::Int32>("echo", 10);
+    sub_group_ =
+        create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    rclcpp::SubscriptionOptions sub_options;
+    sub_options.callback_group = sub_group_;
+    subscription_ = create_subscription<std_msgs::msg::Int32>(
+        "chatter", 10,
+        [this](const std_msgs::msg::Int32::SharedPtr msg) {
+          echo_publisher_->publish(*msg);
+        },
+        sub_options);
+  }
+
+private:
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr subscription_;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr echo_publisher_;
+  rclcpp::CallbackGroup::SharedPtr sub_group_;
+};
+
+int main(int argc, char *argv[]) {
+  // rclcpp::init() must precede constructing CallbackIsolatedExecutor: its
+  // constructor creates an internal publisher node.
+  rclcpp::init(argc, argv);
+  {
+    auto talker = std::make_shared<TalkerNode>();
+    auto listener = std::make_shared<ListenerNode>();
+    auto executor = std::make_shared<CallbackIsolatedExecutor>();
+    executor->add_node(talker);
+    executor->add_node(listener);
+    // Blocks until SIGINT (launch_testing teardown) flips rclcpp::ok() false.
+    executor->spin();
+  }
+  rclcpp::shutdown();
+  return 0;
+}

--- a/callback_isolated_executor/test/test_cie_pubsub.launch.py
+++ b/callback_isolated_executor/test/test_cie_pubsub.launch.py
@@ -24,7 +24,6 @@ def generate_test_description():
     cie_pubsub_node = launch_ros.actions.Node(
         package="callback_isolated_executor",
         executable="cie_pubsub_test_node",
-        name="cie_pubsub_test_node",
         output="screen",
     )
     return (

--- a/callback_isolated_executor/test/test_cie_pubsub.launch.py
+++ b/callback_isolated_executor/test/test_cie_pubsub.launch.py
@@ -1,0 +1,78 @@
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import pytest
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Int32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    cie_pubsub_node = launch_ros.actions.Node(
+        package="callback_isolated_executor",
+        executable="cie_pubsub_test_node",
+        name="cie_pubsub_test_node",
+        output="screen",
+    )
+    return (
+        launch.LaunchDescription(
+            [cie_pubsub_node, launch_testing.actions.ReadyToTest()]
+        ),
+        {"cie_pubsub_node": cie_pubsub_node},
+    )
+
+
+class TestCiePubSub(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = Node("cie_pubsub_test_observer")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_echo_messages_flow(self):
+        received = []
+        self.node.create_subscription(
+            Int32, "echo", lambda msg: received.append(msg.data), 10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + 15 * 1_000_000_000
+        target_count = 5
+        while (
+            len(received) < target_count
+            and self.node.get_clock().now().nanoseconds < end_time
+        ):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.assertGreaterEqual(
+            len(received),
+            target_count,
+            f"Expected >= {target_count} echo messages, got {len(received)}: {received}",
+        )
+        # Values come from an incrementing counter; the observed subsequence must
+        # be strictly increasing. We do not require start==0 because discovery
+        # latency may drop the first few messages.
+        for earlier, later in zip(received, received[1:]):
+            self.assertLess(earlier, later)
+
+
+@launch_testing.post_shutdown_test()
+class TestCiePubSubShutdown(unittest.TestCase):
+    def test_exit_code(self, proc_info, cie_pubsub_node):
+        # 0 = clean return after spin(); -2 = terminated by SIGINT (distro-dependent).
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, -2], process=cie_pubsub_node
+        )

--- a/callback_isolated_executor/test/test_cie_pubsub.launch.py
+++ b/callback_isolated_executor/test/test_cie_pubsub.launch.py
@@ -7,7 +7,14 @@ import launch_testing.asserts
 import launch_testing.markers
 import pytest
 import rclpy
+from cie_config_msgs.msg import CallbackGroupInfo
 from rclpy.node import Node
+from rclpy.qos import (
+    QoSDurabilityPolicy,
+    QoSHistoryPolicy,
+    QoSProfile,
+    QoSReliabilityPolicy,
+)
 from std_msgs.msg import Int32
 
 
@@ -43,30 +50,65 @@ class TestCiePubSub(unittest.TestCase):
     def tearDown(self):
         self.node.destroy_node()
 
+    def _spin_until(self, predicate, timeout_sec):
+        end_time = self.node.get_clock().now().nanoseconds + int(
+            timeout_sec * 1_000_000_000
+        )
+        while (
+            not predicate()
+            and self.node.get_clock().now().nanoseconds < end_time
+        ):
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
     def test_echo_messages_flow(self):
         received = []
         self.node.create_subscription(
             Int32, "echo", lambda msg: received.append(msg.data), 10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + 15 * 1_000_000_000
-        target_count = 5
-        while (
-            len(received) < target_count
-            and self.node.get_clock().now().nanoseconds < end_time
-        ):
-            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self._spin_until(lambda: len(received) >= 5, timeout_sec=15.0)
 
         self.assertGreaterEqual(
             len(received),
-            target_count,
-            f"Expected >= {target_count} echo messages, got {len(received)}: {received}",
+            5,
+            f"Expected >= 5 echo messages, got {len(received)}: {received}",
         )
         # Values come from an incrementing counter; the observed subsequence must
         # be strictly increasing. We do not require start==0 because discovery
         # latency may drop the first few messages.
         for earlier, later in zip(received, received[1:]):
             self.assertLess(earlier, later)
+
+    def test_callback_groups_isolated(self):
+        # CIE publishes one (callback_group_id, thread_id) per callback group on a
+        # transient_local topic, so a late-joining subscriber still receives them.
+        # Distinct thread ids prove the callbacks are isolated onto separate threads.
+        infos = []
+        qos = QoSProfile(
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            history=QoSHistoryPolicy.KEEP_ALL,
+        )
+        self.node.create_subscription(
+            CallbackGroupInfo,
+            "/cie_thread_configurator/callback_group_info",
+            lambda msg: infos.append((msg.callback_group_id, msg.thread_id)),
+            qos,
+        )
+
+        self._spin_until(lambda: len(infos) >= 2, timeout_sec=15.0)
+
+        self.assertGreaterEqual(
+            len(infos),
+            2,
+            f"Expected >= 2 callback group infos, got {infos}",
+        )
+        thread_ids = {thread_id for _, thread_id in infos}
+        self.assertGreaterEqual(
+            len(thread_ids),
+            2,
+            f"Expected callbacks isolated across >= 2 threads, got {infos}",
+        )
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Description

Add a `launch_testing` integration test that exercises `CallbackIsolatedExecutor` (CIE) at runtime with a minimal publisher and subscriber, and wire CI to run it on both Humble and Jazzy. Until now the repository had no functional tests (the `BUILD_TESTING` blocks only ran `ament_lint_auto`, and CI did `colcon build` with a `# TODO: run tests`), so "the build passes" did not imply "CIE actually works". This test closes that gap by verifying both that messages flow end-to-end and that CIE actually isolates callbacks onto separate threads.

What it does:

- **Test node** (`callback_isolated_executor/test/cie_pubsub_test_node.cpp`): a talker node publishes an incrementing `std_msgs/Int32` on `chatter` from a wall-timer in a MutuallyExclusive callback group, and a listener node subscribes to `chatter` and republishes the value to `echo` from its own callback group. Both nodes are added to a single `CallbackIsolatedExecutor` and spun. Two separate nodes are used so the multi-node path in `spin()` is exercised and the subscriber's execution is observable from outside the process (via `echo`).
- **Launch test** (`callback_isolated_executor/test/test_cie_pubsub.launch.py`): an `rclpy` observer runs two checks against the live process:
  - `test_echo_messages_flow`: subscribes to `echo` and asserts it receives at least 5 messages within a timeout and that the values increase monotonically, proving both the publisher and subscriber callbacks actually ran inside CIE.
  - `test_callback_groups_isolated`: subscribes to `/cie_thread_configurator/callback_group_info` (the topic CIE publishes a `(callback_group_id, thread_id)` pair on for each callback group) and asserts at least two distinct thread ids are reported. This directly verifies CIE's defining behavior: isolating callbacks onto separate threads, which the echo round-trip alone does not establish. The topic is `transient_local`, so the late-joining observer still receives all latched samples without a timing race.
  - A post-shutdown check asserts the process exits cleanly on SIGINT.
- **Build/packaging**: the test node is built and installed to `lib/${PROJECT_NAME}` and the launch test registered via `add_launch_test`, all under a second `BUILD_TESTING` block (placed after the library target so it can link against it). `launch_testing_ament_cmake`, `launch_ros`, and `rclpy` are added as `test_depend` (`cie_config_msgs`, needed for the `CallbackGroupInfo` message, is already a regular dependency).
- **CI**: the `# TODO: run tests` is replaced with a `colcon test` step that runs on both Humble and Jazzy.

Design notes / trade-offs:

- CIE runs standalone: the `thread_configurator` node is not required, because `publish_callback_group_info` just publishes on a transient-local topic that no-ops when nobody subscribes. The test observes that topic directly but does not launch the configurator.
- Shutdown is driven by SIGINT. CIE's `spin()` spawns one thread per callback group and joins them, and `cancel()` is not propagated to the per-group executors; on SIGINT the per-group spin loops observe `rclcpp::ok() == false` and return, so the process exits cleanly. The exit-code assertion accepts both `0` and `-2` to absorb distro differences.
- The CI test step intentionally runs only the `launch_test` label (`--ctest-args -L launch_test`). The ament C++ linters (copyright/cpplint/uncrustify) are not used by this project, which enforces style via clang-format in the separate `run-pre-commit` workflow, and the existing sources predate those linters. Keeping the linters out of the CI gate avoids failing on pre-existing, unadopted lint while still running the new functional test. The lint scaffolding in `CMakeLists.txt` is left untouched.
- Flakiness is mitigated with a 10 Hz talker, QoS matching the publishers, generous timeouts, low thresholds, and a monotonic-increase (not exact-start) assertion. The `callback_group_info` check relies on `transient_local` durability so it is not sensitive to subscribe timing.

Verified locally on Humble: `colcon build` + `colcon test --ctest-args -L launch_test` passes (all three checks green, clean SIGINT shutdown).

## Related links

## How was this PR tested?

## Notes for reviewers