### PR TITLE
test: add unit tests for create_callback_group_id

### DIFF
--- a/cie_thread_configurator/CMakeLists.txt
+++ b/cie_thread_configurator/CMakeLists.txt
@@ -20,6 +20,13 @@ if(BUILD_TESTING)
   # uncomment the line when this package is not in a git repo
   #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(std_msgs REQUIRED)
+
+  ament_add_ros_isolated_gtest(test_util test/test_util.cpp)
+  target_link_libraries(test_util thread_configurator)
+  ament_target_dependencies(test_util rclcpp std_msgs cie_config_msgs)
 endif()
 
 add_library(thread_configurator SHARED src/util.cpp)

--- a/cie_thread_configurator/CMakeLists.txt
+++ b/cie_thread_configurator/CMakeLists.txt
@@ -11,24 +11,6 @@ find_package(rclcpp REQUIRED)
 find_package(cie_config_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-
-  find_package(ament_cmake_ros REQUIRED)
-  find_package(std_msgs REQUIRED)
-
-  ament_add_ros_isolated_gtest(test_util test/test_util.cpp)
-  target_link_libraries(test_util thread_configurator)
-  ament_target_dependencies(test_util rclcpp std_msgs cie_config_msgs)
-endif()
-
 add_library(thread_configurator SHARED src/util.cpp)
 ament_target_dependencies(thread_configurator rclcpp cie_config_msgs)
 
@@ -73,4 +55,24 @@ install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
 ament_export_dependencies(cie_config_msgs yaml-cpp rclcpp)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+
+  ament_add_ros_isolated_gtest(test_util test/test_util.cpp)
+  target_link_libraries(test_util thread_configurator)
+  ament_target_dependencies(test_util rclcpp std_msgs std_srvs)
+endif()
+
 ament_package()

--- a/cie_thread_configurator/package.xml
+++ b/cie_thread_configurator/package.xml
@@ -21,6 +21,7 @@
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
 
   <depend>rclcpp</depend>
   <depend>yaml-cpp</depend>

--- a/cie_thread_configurator/package.xml
+++ b/cie_thread_configurator/package.xml
@@ -19,6 +19,9 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>std_msgs</test_depend>
+
   <depend>rclcpp</depend>
   <depend>yaml-cpp</depend>
 

--- a/cie_thread_configurator/test/test_util.cpp
+++ b/cie_thread_configurator/test/test_util.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "gtest/gtest.h"
+
+#include "cie_thread_configurator/cie_thread_configurator.hpp"
+
+using cie_thread_configurator::create_callback_group_id;
+
+// Each test runs in its own rclcpp context so node names and the ROS graph
+// do not leak between cases.
+class CreateCallbackGroupIdTest : public ::testing::Test {
+protected:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  // Helper: attach a subscription on an absolute topic to the given group.
+  rclcpp::SubscriptionBase::SharedPtr
+  add_subscription(const rclcpp::Node::SharedPtr &node,
+                   const rclcpp::CallbackGroup::SharedPtr &group,
+                   const std::string &topic) {
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = group;
+    return node->create_subscription<std_msgs::msg::String>(
+        topic, rclcpp::QoS(10),
+        [](const std_msgs::msg::String::ConstSharedPtr) {}, options);
+  }
+};
+
+// A node at the root namespace must produce a single leading slash
+// (e.g. "/node", not "//node"), then the entity descriptor.
+TEST_F(CreateCallbackGroupIdTest, RootNamespaceWithSubscription) {
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto sub = add_subscription(node, group, "/chatter");
+  ASSERT_NE(sub, nullptr);
+
+  EXPECT_EQ(create_callback_group_id(group, node),
+            "/test_node@Subscription(/chatter)");
+}
+
+// A non-root namespace exercises the "ns + '/'" branch.
+TEST_F(CreateCallbackGroupIdTest, NonRootNamespace) {
+  auto node = std::make_shared<rclcpp::Node>("test_node", "my_ns");
+  auto group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto sub = add_subscription(node, group, "/chatter");
+  ASSERT_NE(sub, nullptr);
+
+  EXPECT_EQ(create_callback_group_id(group, node),
+            "/my_ns/test_node@Subscription(/chatter)");
+}
+
+// The trailing '@' separator appended after the last entity must be removed.
+TEST_F(CreateCallbackGroupIdTest, TrailingSeparatorStripped) {
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto sub = add_subscription(node, group, "/chatter");
+  ASSERT_NE(sub, nullptr);
+
+  const std::string id = create_callback_group_id(group, node);
+  ASSERT_FALSE(id.empty());
+  EXPECT_NE(id.back(), '@');
+}
+
+// Timers have no name, so they are identified by their period in nanoseconds.
+// 100 ms == 100000000 ns.
+TEST_F(CreateCallbackGroupIdTest, TimerEntityUsesPeriodNanoseconds) {
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto timer =
+      node->create_wall_timer(std::chrono::milliseconds(100), []() {}, group);
+  ASSERT_NE(timer, nullptr);
+
+  EXPECT_EQ(create_callback_group_id(group, node),
+            "/test_node@Timer(100000000)");
+}
+
+// The Node overload must delegate to the NodeBaseInterface overload and yield
+// an identical result.
+TEST_F(CreateCallbackGroupIdTest,
+       NodeBaseInterfaceOverloadMatchesNodeOverload) {
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group =
+      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto sub = add_subscription(node, group, "/chatter");
+  ASSERT_NE(sub, nullptr);
+
+  const std::string id_base =
+      create_callback_group_id(group, node->get_node_base_interface());
+  const std::string id_node = create_callback_group_id(group, node);
+
+  EXPECT_EQ(id_base, id_node);
+  EXPECT_EQ(id_base, "/test_node@Subscription(/chatter)");
+}

--- a/cie_thread_configurator/test/test_util.cpp
+++ b/cie_thread_configurator/test/test_util.cpp
@@ -18,6 +18,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
+#include "std_srvs/srv/empty.hpp"
 #include "gtest/gtest.h"
 
 #include "cie_thread_configurator/cie_thread_configurator.hpp"
@@ -31,7 +32,12 @@ protected:
   void SetUp() override { rclcpp::init(0, nullptr); }
   void TearDown() override { rclcpp::shutdown(); }
 
-  // Helper: attach a subscription on an absolute topic to the given group.
+  rclcpp::CallbackGroup::SharedPtr
+  make_group(const rclcpp::Node::SharedPtr &node) {
+    return node->create_callback_group(
+        rclcpp::CallbackGroupType::MutuallyExclusive);
+  }
+
   rclcpp::SubscriptionBase::SharedPtr
   add_subscription(const rclcpp::Node::SharedPtr &node,
                    const rclcpp::CallbackGroup::SharedPtr &group,
@@ -42,74 +48,165 @@ protected:
         topic, rclcpp::QoS(10),
         [](const std_msgs::msg::String::ConstSharedPtr) {}, options);
   }
+
+  rclcpp::ServiceBase::SharedPtr
+  add_service(const rclcpp::Node::SharedPtr &node,
+              const rclcpp::CallbackGroup::SharedPtr &group,
+              const std::string &name) {
+    return node->create_service<std_srvs::srv::Empty>(
+        name,
+        [](const std::shared_ptr<std_srvs::srv::Empty::Request>,
+           std::shared_ptr<std_srvs::srv::Empty::Response>) {},
+        rclcpp::ServicesQoS().get_rmw_qos_profile(), group);
+  }
+
+  rclcpp::ClientBase::SharedPtr
+  add_client(const rclcpp::Node::SharedPtr &node,
+             const rclcpp::CallbackGroup::SharedPtr &group,
+             const std::string &name) {
+    return node->create_client<std_srvs::srv::Empty>(
+        name, rclcpp::ServicesQoS().get_rmw_qos_profile(), group);
+  }
+
+  rclcpp::TimerBase::SharedPtr
+  add_timer(const rclcpp::Node::SharedPtr &node,
+            const rclcpp::CallbackGroup::SharedPtr &group,
+            std::chrono::nanoseconds period) {
+    return node->create_wall_timer(period, []() {}, group);
+  }
 };
 
 // A node at the root namespace must produce a single leading slash
 // (e.g. "/node", not "//node"), then the entity descriptor.
 TEST_F(CreateCallbackGroupIdTest, RootNamespaceWithSubscription) {
+  // Arrange
   auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto group =
-      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto group = make_group(node);
   auto sub = add_subscription(node, group, "/chatter");
   ASSERT_NE(sub, nullptr);
 
-  EXPECT_EQ(create_callback_group_id(group, node),
-            "/test_node@Subscription(/chatter)");
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node@Subscription(/chatter)");
 }
 
 // A non-root namespace exercises the "ns + '/'" branch.
 TEST_F(CreateCallbackGroupIdTest, NonRootNamespace) {
+  // Arrange
   auto node = std::make_shared<rclcpp::Node>("test_node", "my_ns");
-  auto group =
-      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto group = make_group(node);
   auto sub = add_subscription(node, group, "/chatter");
   ASSERT_NE(sub, nullptr);
 
-  EXPECT_EQ(create_callback_group_id(group, node),
-            "/my_ns/test_node@Subscription(/chatter)");
-}
-
-// The trailing '@' separator appended after the last entity must be removed.
-TEST_F(CreateCallbackGroupIdTest, TrailingSeparatorStripped) {
-  auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto group =
-      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  auto sub = add_subscription(node, group, "/chatter");
-  ASSERT_NE(sub, nullptr);
-
+  // Act
   const std::string id = create_callback_group_id(group, node);
-  ASSERT_FALSE(id.empty());
-  EXPECT_NE(id.back(), '@');
+
+  // Assert
+  EXPECT_EQ(id, "/my_ns/test_node@Subscription(/chatter)");
 }
 
-// Timers have no name, so they are identified by their period in nanoseconds.
+// A service entity is rendered as Service(<name>).
+TEST_F(CreateCallbackGroupIdTest, ServiceEntity) {
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group = make_group(node);
+  auto service = add_service(node, group, "/srv");
+  ASSERT_NE(service, nullptr);
+
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node@Service(/srv)");
+}
+
+// A client entity is rendered as Client(<name>).
+TEST_F(CreateCallbackGroupIdTest, ClientEntity) {
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group = make_group(node);
+  auto client = add_client(node, group, "/srv");
+  ASSERT_NE(client, nullptr);
+
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node@Client(/srv)");
+}
+
+// A timer has no name, so it is identified by its period in nanoseconds.
 // 100 ms == 100000000 ns.
 TEST_F(CreateCallbackGroupIdTest, TimerEntityUsesPeriodNanoseconds) {
+  // Arrange
   auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto group =
-      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  auto timer =
-      node->create_wall_timer(std::chrono::milliseconds(100), []() {}, group);
+  auto group = make_group(node);
+  auto timer = add_timer(node, group, std::chrono::milliseconds(100));
   ASSERT_NE(timer, nullptr);
 
-  EXPECT_EQ(create_callback_group_id(group, node),
-            "/test_node@Timer(100000000)");
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node@Timer(100000000)");
+}
+
+// Multiple entities are joined with '@'. collect_all_ptrs emits them in the
+// order: subscriptions, services, clients, then timers. This test pins that
+// ordering and the internal '@' joining.
+TEST_F(CreateCallbackGroupIdTest, MultipleEntitiesAreJoinedInStorageOrder) {
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group = make_group(node);
+  auto sub = add_subscription(node, group, "/chatter");
+  auto timer = add_timer(node, group, std::chrono::milliseconds(100));
+  auto service = add_service(node, group, "/srv");
+  auto client = add_client(node, group, "/cli");
+  ASSERT_NE(sub, nullptr);
+  ASSERT_NE(timer, nullptr);
+  ASSERT_NE(service, nullptr);
+  ASSERT_NE(client, nullptr);
+
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node@Subscription(/chatter)@Service(/srv)@Client(/"
+                "cli)@Timer(100000000)");
+}
+
+// With no entities, only the bare "node@" prefix is built, so stripping the
+// trailing '@' must yield exactly the node identifier and nothing else.
+TEST_F(CreateCallbackGroupIdTest, EmptyGroupStripsTrailingSeparator) {
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto group = make_group(node);
+
+  // Act
+  const std::string id = create_callback_group_id(group, node);
+
+  // Assert
+  EXPECT_EQ(id, "/test_node");
 }
 
 // The Node overload must delegate to the NodeBaseInterface overload and yield
 // an identical result.
 TEST_F(CreateCallbackGroupIdTest,
        NodeBaseInterfaceOverloadMatchesNodeOverload) {
+  // Arrange
   auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto group =
-      node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto group = make_group(node);
   auto sub = add_subscription(node, group, "/chatter");
   ASSERT_NE(sub, nullptr);
 
+  // Act
   const std::string id_base =
       create_callback_group_id(group, node->get_node_base_interface());
   const std::string id_node = create_callback_group_id(group, node);
 
+  // Assert
   EXPECT_EQ(id_base, id_node);
   EXPECT_EQ(id_base, "/test_node@Subscription(/chatter)");
 }


### PR DESCRIPTION
## Description
Adds unit tests for `create_callback_group_id` (`cie_thread_configurator/src/util.cpp`), addressing the first unit-test item in #38.

Covers:
- Root namespace produces a single leading slash (`/node`, not `//node`)
- Non-root namespace path (`/ns/node`)
- The trailing `@` separator is stripped from the result
- Timer entities are identified by period in nanoseconds
- The `Node` overload matches the `NodeBaseInterface` overload

Tests use `ament_add_ros_isolated_gtest` so each case runs in an isolated ROS context.

## Related links
Part of #38

## How was this PR tested?
Built and ran locally on ROS 2 Humble:
- `colcon test --packages-select cie_thread_configurator` — all 5 gtest cases pass
- `pre-commit run --files ...` passes (clang-format clean)

Note: the gtest target is not picked up by the current CI test step, which filters to `-L launch_test`. Wiring CI to run gtest unit tests is itself an open item in #38 and is out of scope for this PR.

## Notes for reviewers
- Scope is limited to `create_callback_group_id` unit tests only, per the suggested starting point in #38.
- The pre-existing ament linter failures (copyright/cpplint/uncrustify) on other files in the package are unrelated to this change and not addressed here.