### PR TITLE
docs: add post-merge checklist for reflecting changes to doc repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,7 @@
 ## How was this PR tested?
 
 ## Notes for reviewers
+
+## Post-merge checklists
+
+- [ ] If this change affects user-facing behavior or documentation, reflect it in [callback_isolated_executor_doc](https://github.com/autowarefoundation/callback_isolated_executor_doc) as needed.


### PR DESCRIPTION
## Description

Add a `Post-merge checklists` section to the PR template so that contributors remember to reflect user-facing or documentation changes into the [callback_isolated_executor_doc](https://github.com/autowarefoundation/callback_isolated_executor_doc) repository when needed.

## Related links

- https://github.com/autowarefoundation/callback_isolated_executor_doc

## How was this PR tested?

N/A (documentation/template change only).

## Notes for reviewers

The checklist item is intentionally conditional ("as needed") so it only applies when a change actually affects user-facing behavior or documentation.