### PR TITLE
fix(cie): sort callback group id entries for stable ids

### DIFF
--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -43,9 +43,13 @@ std::string create_callback_group_id(
 
   auto timer_func = [&entries](const rclcpp::TimerBase::SharedPtr &timer) {
     std::shared_ptr<const rcl_timer_t> timer_handle = timer->get_timer_handle();
-    int64_t period;
+    int64_t period = 0;
     rcl_ret_t ret = rcl_timer_get_period(timer_handle.get(), &period);
-    (void)ret;
+    // Fall back to 0 on failure so the id stays deterministic instead of
+    // depending on an uninitialized value.
+    if (ret != RCL_RET_OK) {
+      period = 0;
+    }
 
     entries.push_back("Timer(" + std::to_string(period) + ")");
   };

--- a/cie_thread_configurator/src/util.cpp
+++ b/cie_thread_configurator/src/util.cpp
@@ -1,11 +1,13 @@
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "cie_config_msgs/msg/callback_group_info.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -17,33 +19,35 @@ namespace cie_thread_configurator {
 std::string create_callback_group_id(
     rclcpp::CallbackGroup::SharedPtr group,
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node) {
-  std::stringstream ss;
-
   std::string ns = std::string(node->get_namespace());
   if (ns != "/")
     ns = ns + "/";
 
-  ss << ns << node->get_name() << "@";
+  std::vector<std::string> entries;
 
-  auto sub_func = [&ss](const rclcpp::SubscriptionBase::SharedPtr &sub) {
-    ss << "Subscription(" << sub->get_topic_name() << ")@";
+  auto sub_func = [&entries](const rclcpp::SubscriptionBase::SharedPtr &sub) {
+    entries.push_back("Subscription(" + std::string(sub->get_topic_name()) +
+                      ")");
   };
 
-  auto service_func = [&ss](const rclcpp::ServiceBase::SharedPtr &service) {
-    ss << "Service(" << service->get_service_name() << ")@";
+  auto service_func =
+      [&entries](const rclcpp::ServiceBase::SharedPtr &service) {
+        entries.push_back("Service(" +
+                          std::string(service->get_service_name()) + ")");
+      };
+
+  auto client_func = [&entries](const rclcpp::ClientBase::SharedPtr &client) {
+    entries.push_back("Client(" + std::string(client->get_service_name()) +
+                      ")");
   };
 
-  auto client_func = [&ss](const rclcpp::ClientBase::SharedPtr &client) {
-    ss << "Client(" << client->get_service_name() << ")@";
-  };
-
-  auto timer_func = [&ss](const rclcpp::TimerBase::SharedPtr &timer) {
+  auto timer_func = [&entries](const rclcpp::TimerBase::SharedPtr &timer) {
     std::shared_ptr<const rcl_timer_t> timer_handle = timer->get_timer_handle();
     int64_t period;
     rcl_ret_t ret = rcl_timer_get_period(timer_handle.get(), &period);
     (void)ret;
 
-    ss << "Timer(" << period << ")@";
+    entries.push_back("Timer(" + std::to_string(period) + ")");
   };
 
   auto waitable_func = [](auto &&) {};
@@ -51,10 +55,20 @@ std::string create_callback_group_id(
   group->collect_all_ptrs(sub_func, service_func, client_func, timer_func,
                           waitable_func);
 
-  std::string ret = ss.str();
-  ret.pop_back();
+  // Sort so the id depends only on the set of entities, not the order they were
+  // registered in. collect_all_ptrs reports entities in registration order,
+  // which can differ between runs (e.g. multi-threaded or hash-ordered
+  // creation). A stable id is required because it is the key matched between
+  // the prerun config-generation run and the production run.
+  std::sort(entries.begin(), entries.end());
 
-  return ret;
+  std::stringstream ss;
+  ss << ns << node->get_name();
+  for (const auto &entry : entries) {
+    ss << "@" << entry;
+  }
+
+  return ss.str();
 }
 
 std::string create_callback_group_id(rclcpp::CallbackGroup::SharedPtr group,

--- a/cie_thread_configurator/test/test_util.cpp
+++ b/cie_thread_configurator/test/test_util.cpp
@@ -153,10 +153,11 @@ TEST_F(CreateCallbackGroupIdTest, TimerEntityUsesPeriodNanoseconds) {
   EXPECT_EQ(id, "/test_node@Timer(100000000)");
 }
 
-// Multiple entities are joined with '@'. collect_all_ptrs emits them in the
-// order: subscriptions, services, clients, then timers. This test pins that
-// ordering and the internal '@' joining.
-TEST_F(CreateCallbackGroupIdTest, MultipleEntitiesAreJoinedInStorageOrder) {
+// Multiple entities are joined with '@' and sorted alphabetically, regardless
+// of the order collect_all_ptrs reports them (subscriptions, services,
+// clients, then timers). Sorting puts them in the order Client < Service <
+// Subscription < Timer.
+TEST_F(CreateCallbackGroupIdTest, MultipleEntitiesAreSortedAlphabetically) {
   // Arrange
   auto node = std::make_shared<rclcpp::Node>("test_node");
   auto group = make_group(node);
@@ -173,8 +174,38 @@ TEST_F(CreateCallbackGroupIdTest, MultipleEntitiesAreJoinedInStorageOrder) {
   const std::string id = create_callback_group_id(group, node);
 
   // Assert
-  EXPECT_EQ(id, "/test_node@Subscription(/chatter)@Service(/srv)@Client(/"
-                "cli)@Timer(100000000)");
+  EXPECT_EQ(id, "/test_node@Client(/cli)@Service(/srv)@Subscription(/"
+                "chatter)@Timer(100000000)");
+}
+
+// The id must depend only on the set of entities, not on the order they were
+// registered. Two groups holding the same subscriptions registered in opposite
+// orders must produce identical ids.
+TEST_F(CreateCallbackGroupIdTest, IdIsIndependentOfRegistrationOrder) {
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+
+  auto group_ascending = make_group(node);
+  auto sub_a1 = add_subscription(node, group_ascending, "/a");
+  auto sub_b1 = add_subscription(node, group_ascending, "/b");
+  ASSERT_NE(sub_a1, nullptr);
+  ASSERT_NE(sub_b1, nullptr);
+
+  auto group_descending = make_group(node);
+  auto sub_b2 = add_subscription(node, group_descending, "/b");
+  auto sub_a2 = add_subscription(node, group_descending, "/a");
+  ASSERT_NE(sub_b2, nullptr);
+  ASSERT_NE(sub_a2, nullptr);
+
+  // Act
+  const std::string id_ascending =
+      create_callback_group_id(group_ascending, node);
+  const std::string id_descending =
+      create_callback_group_id(group_descending, node);
+
+  // Assert
+  EXPECT_EQ(id_ascending, id_descending);
+  EXPECT_EQ(id_ascending, "/test_node@Subscription(/a)@Subscription(/b)");
 }
 
 // With no entities, only the bare "node@" prefix is built, so stripping the


### PR DESCRIPTION
## Description

`create_callback_group_id` builds the id by iterating the entities collected from a callback group via `collect_all_ptrs`. Until now the entities were appended in the order `collect_all_ptrs` reports them, which is the order they were registered in the group.

That order is not guaranteed to be stable across runs: entities registered from multiple threads, or generated by iterating a hash-ordered container, can be reported in a different order on a later run. Because the id is the key matched between the prerun config-generation run (which writes the YAML template) and the production run (`thread_configurator_node` looks it up with `id_to_thread_config_.find(...)`), an order-dependent id can silently fail to match, and the thread configuration is then never applied.

This change collects the entity descriptors into a vector, sorts them, and then joins them with `@`, so the id depends only on the *set* of entities, not the order they were registered in. The sorted order is `Client < Service < Subscription < Timer` (ASCII order of the descriptor strings).

Tests:
- `MultipleEntitiesAreJoinedInStorageOrder` (which pinned the old registration/storage order) is replaced by `MultipleEntitiesAreSortedAlphabetically`, asserting the new sorted order.
- A new `IdIsIndependentOfRegistrationOrder` test registers the same two subscriptions in opposite orders into two groups and asserts the ids are identical.

Migration note: this changes the id string for any callback group that holds two or more entities. Configs whose ids were generated before this change must be regenerated by re-running the prerun step.

## Related links

## How was this PR tested?

Built and ran locally on ROS 2 Humble:
- `colcon build --packages-select cie_thread_configurator`
- `colcon test --packages-select cie_thread_configurator --ctest-args -R test_util` — all 9 gtest cases pass

## Notes for reviewers

## Post-merge checklists

- [ ] If this change affects user-facing behavior or documentation, reflect it in [callback_isolated_executor_doc](https://github.com/autowarefoundation/callback_isolated_executor_doc) as needed.