### PR TITLE
fix: test: add unit tests for create_callback_group_id

### DIFF
--- a/cie_thread_configurator/CMakeLists.txt
+++ b/cie_thread_configurator/CMakeLists.txt
@@ -82,3 +82,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
+
+ament_add_ros_isolated_gtest(test_create_callback_group_id test/test_create_callback_group_id.cpp)
+target_link_libraries(test_create_callback_group_id ${PROJECT_NAME})

--- a/tests/test_create_callback_group_id.cpp
+++ b/tests/test_create_callback_group_id.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <set>
+
+#include "cie_thread_configurator/cie_thread_configurator.hpp"
+
+TEST(CreateCallbackGroupId, DeterministicAndDistinct) {
+  using ::cie_thread_configurator::create_callback_group_id;
+  // Exercise the pure string-ID helper with simple inputs.
+  // Parameter types follow the declaration in the project header.
+  auto id1 = create_callback_group_id("v1_0", "v1_1");
+  auto id2 = create_callback_group_id("v1_0", "v1_1");
+  auto id3 = create_callback_group_id("v2_0", "v2_1");
+  EXPECT_EQ(id1, id2);
+  EXPECT_NE(id1, id3);
+  EXPECT_FALSE(id1.empty());
+}


### PR DESCRIPTION
## Summary

test: add unit tests for create_callback_group_id

## Changes

- tests\test_create_callback_group_id.cpp
- cie_thread_configurator\CMakeLists.txt

Fixes #38
